### PR TITLE
Move dt parameter from Mirheo() to Mirheo::run()

### DIFF
--- a/src/mirheo/core/bouncers/from_mesh.cu
+++ b/src/mirheo/core/bouncers/from_mesh.cu
@@ -154,7 +154,7 @@ void BounceFromMesh::exec(ParticleVector *pv, CellList *cl, ParticleVectorLocali
             getNblocks(fineTable_.nCollisions[0], nthreads), nthreads, 0, stream,
             vertexView, pvView, ov_->mesh.get(),
             fineTable_.nCollisions[0], devFineTable.indices, collisionTimes_.devPtr(),
-            getState()->dt, bounceKernel );
+            getState()->getDt(), bounceKernel );
 
     }, varBounceKernel_);
 

--- a/src/mirheo/core/bouncers/from_rod.cu
+++ b/src/mirheo/core/bouncers/from_rod.cu
@@ -108,7 +108,7 @@ void BounceFromRod::exec(ParticleVector *pv, CellList *cl, ParticleVectorLocalit
             rod_bounce_kernels::performBouncing,
             getNblocks(nCollisions, nthreads), nthreads, 0, stream,
             rvView, radius_, pvView, nCollisions, devCollisionTable.indices, collisionTimes.devPtr(),
-            getState()->dt, bounceKernel);
+            getState()->getDt(), bounceKernel);
 
     }, varBounceKernel_);
 }

--- a/src/mirheo/core/bouncers/from_shape.cu
+++ b/src/mirheo/core/bouncers/from_shape.cu
@@ -81,7 +81,7 @@ void BounceFromRigidShape<Shape>::exec(ParticleVector *pv, CellList *cl, Particl
         SAFE_KERNEL_LAUNCH(
             shape_bounce_kernels::bounce,
             nblocks, nthreads, smem, stream,
-            ovView, pvView, cl->cellInfo(), getState()->dt,
+            ovView, pvView, cl->cellInfo(), getState()->getDt(),
             bounceKernel);
 
     }, varBounceKernel_);

--- a/src/mirheo/core/integrators/const_omega.cu
+++ b/src/mirheo/core/integrators/const_omega.cu
@@ -38,7 +38,7 @@ void IntegratorConstOmega::execute(ParticleVector *pv, cudaStream_t stream)
         p.r  = domain.global2local(gr_c + center);
     };
 
-    integrate(pv, getState()->dt, rotate, stream);
+    integrate(pv, getState()->getDt(), rotate, stream);
     invalidatePV_(pv);
 }
 

--- a/src/mirheo/core/integrators/minimize.cu
+++ b/src/mirheo/core/integrators/minimize.cu
@@ -20,7 +20,7 @@ IntegratorMinimize::IntegratorMinimize(const MirState *state, Loader&, const Con
 void IntegratorMinimize::execute(ParticleVector *pv, cudaStream_t stream)
 {
     const auto t  = static_cast<real>(getState()->currentTime);
-    const auto dt = static_cast<real>(getState()->dt);
+    const auto dt = static_cast<real>(getState()->getDt());
 
     auto st2 = [max = maxDisplacement_] __device__ (Particle& p, real3 f, real invm, real dt)
     {

--- a/src/mirheo/core/integrators/oscillate.cu
+++ b/src/mirheo/core/integrators/oscillate.cu
@@ -37,7 +37,7 @@ void IntegratorOscillate::execute(ParticleVector *pv, cudaStream_t stream)
         p.r += p.u * dt;
     };
 
-    integrate(pv, getState()->dt, oscillate, stream);
+    integrate(pv, getState()->getDt(), oscillate, stream);
     invalidatePV_(pv);
 }
 

--- a/src/mirheo/core/integrators/rigid_vv.cu
+++ b/src/mirheo/core/integrators/rigid_vv.cu
@@ -121,7 +121,7 @@ static void integrateRigidMotions(const ROVviewWithOldMotion& view, real dt, cud
 
 void IntegratorVVRigid::execute(ParticleVector *pv, cudaStream_t stream)
 {
-    const real dt = getState()->dt;
+    const real dt = getState()->getDt();
     auto rov = dynamic_cast<RigidObjectVector*> (pv);
 
     debug("Integrating %d rigid objects %s (total %d particles), timestep is %f",

--- a/src/mirheo/core/integrators/sub_step.cpp
+++ b/src/mirheo/core/integrators/sub_step.cpp
@@ -40,8 +40,6 @@ IntegratorSubStep::IntegratorSubStep(const MirState *state, const std::string& n
     debug("setup substep integrator '%s' for %d substeps with sub integrator '%s' and fast forces '%s'",
           getCName(), substeps_, subIntegrator_->getCName(), ffNames.c_str());
 
-    updateSubState_();
-
     subIntegrator_->setState(&subState_);
 }
 
@@ -109,7 +107,7 @@ void IntegratorSubStep::execute(ParticleVector *pv, cudaStream_t stream)
 
         subIntegrator_->execute(pv, stream);
 
-        subState_.currentTime += subState_.dt;
+        subState_.currentTime += subState_.getDt();
         subState_.currentStep ++;
     }
 
@@ -133,7 +131,7 @@ void IntegratorSubStep::setPrerequisites(ParticleVector *pv)
 void IntegratorSubStep::updateSubState_()
 {
     subState_ = *getState();
-    subState_.dt = getState()->dt / static_cast<real>(substeps_);
+    subState_.setDt(getState()->getDt() / static_cast<real>(substeps_));
 }
 
 } // namespace mirheo

--- a/src/mirheo/core/integrators/sub_step.h
+++ b/src/mirheo/core/integrators/sub_step.h
@@ -6,6 +6,7 @@
 #include <mirheo/core/containers.h>
 #include <mirheo/core/datatypes.h>
 
+#include <memory>
 #include <vector>
 
 namespace mirheo

--- a/src/mirheo/core/integrators/translate.cu
+++ b/src/mirheo/core/integrators/translate.cu
@@ -29,7 +29,7 @@ void IntegratorTranslate::execute(ParticleVector *pv, cudaStream_t stream)
         p.r += p.u * dt;
     };
 
-    integrate(pv, getState()->dt, translate, stream);
+    integrate(pv, getState()->getDt(), translate, stream);
     invalidatePV_(pv);
 }
 

--- a/src/mirheo/core/integrators/vv.cu
+++ b/src/mirheo/core/integrators/vv.cu
@@ -76,7 +76,7 @@ template<class ForcingTerm>
 void IntegratorVV<ForcingTerm>::execute(ParticleVector *pv, cudaStream_t stream)
 {
     const auto t  = static_cast<real>(getState()->currentTime);
-    const auto dt = static_cast<real>(getState()->dt);
+    const auto dt = static_cast<real>(getState()->getDt());
 
     static_assert(std::is_same<decltype(forcingTerm_.setup(pv, t)), void>::value,
             "Forcing term functor must provide member"

--- a/src/mirheo/core/interactions/membrane/membrane.h
+++ b/src/mirheo/core/interactions/membrane/membrane.h
@@ -41,7 +41,7 @@ static membrane_forces_kernels::GPU_CommonMembraneParameters setParams(const Com
 
     if (devP.fluctuationForces)
     {
-        const auto dt = state->dt;
+        const auto dt = state->getDt();
         devP.seed = stepGen.generate(state);
         devP.sigma_rnd = math::sqrt(2 * p.kBT * p.gammaC / dt);
     }

--- a/src/mirheo/core/interactions/pairwise/kernels/density.h
+++ b/src/mirheo/core/interactions/pairwise/kernels/density.h
@@ -36,7 +36,7 @@ public:
     {}
 
     /// generic constructor
-    PairwiseDensity(real rc, const ParamsType& p, __UNUSED real dt, __UNUSED long seed=42424242) :
+    PairwiseDensity(real rc, const ParamsType& p, __UNUSED long seed=42424242) :
         PairwiseDensity{rc,
                         mpark::get<typename DensityKernel::ParamsType>(p.varDensityKernelParams)}
     {}

--- a/src/mirheo/core/interactions/pairwise/kernels/lj.h
+++ b/src/mirheo/core/interactions/pairwise/kernels/lj.h
@@ -29,7 +29,7 @@ public:
     {}
 
     /// Generic constructor
-    PairwiseLJ(real rc, const ParamsType& p, __UNUSED real dt, __UNUSED long seed=42424242) :
+    PairwiseLJ(real rc, const ParamsType& p, __UNUSED long seed=42424242) :
         PairwiseLJ{rc, p.epsilon, p.sigma}
     {}
 

--- a/src/mirheo/core/interactions/pairwise/kernels/norandom_dpd.h
+++ b/src/mirheo/core/interactions/pairwise/kernels/norandom_dpd.h
@@ -28,18 +28,18 @@ public:
     using ParamsType   = NoRandomDPDParams; ///< parameters that are used to create this object
 
     /// constructor
-    PairwiseNorandomDPD(real rc, real a, real gamma, real kBT, real dt, real power) :
+    PairwiseNorandomDPD(real rc, real a, real gamma, real kBT, real power) :
         ParticleFetcherWithVelocity(rc),
         a_(a),
         gamma_(gamma),
-        sigma_(math::sqrt(2 * gamma_ * kBT / dt)),
+        kBT_(kBT),
         power_(power),
         invrc_(1.0 / rc)
     {}
 
     /// Generic constructor
-    PairwiseNorandomDPD(real rc, const ParamsType& p, real dt, long seed=42424242) :
-        PairwiseNorandomDPD(rc, p.a, p.gamma, p.kBT, dt, p.power)
+    PairwiseNorandomDPD(real rc, const ParamsType& p, long seed=42424242) :
+        PairwiseNorandomDPD(rc, p.a, p.gamma, p.kBT, p.power)
     {}
 
     /// evaluate the force
@@ -74,6 +74,16 @@ public:
         return (const HandlerType&) (*this);
     }
 
+    void setup(__UNUSED LocalParticleVector *lpv1,
+               __UNUSED LocalParticleVector *lpv2,
+               __UNUSED CellList *cl1,
+               __UNUSED CellList *cl2,
+               const MirState *state) override
+    {
+        sigma_ = math::sqrt(2 * gamma_ * kBT_ / state->getDt());
+    }
+
+
     /// \return type name string
     static std::string getTypeName()
     {
@@ -83,7 +93,8 @@ public:
 protected:
     real a_; ///< conservative force magnitude
     real gamma_; ///< viscous force coefficient
-    real sigma_; ///< random force coefficient
+    real sigma_{NAN}; ///< random force coefficient, depends on dt
+    real kBT_; ///< temperature
     real power_; ///< viscous kernel envelope power
     real invrc_; ///< 1 / rc
 };

--- a/src/mirheo/core/interactions/pairwise/kernels/repulsive_lj.h
+++ b/src/mirheo/core/interactions/pairwise/kernels/repulsive_lj.h
@@ -179,7 +179,7 @@ public:
     }
 
     /// Generic constructor
-    PairwiseRepulsiveLJ(real rc, const ParamsType& p, __UNUSED real dt, __UNUSED long seed=42424242) :
+    PairwiseRepulsiveLJ(real rc, const ParamsType& p, __UNUSED long seed=42424242) :
         PairwiseRepulsiveLJ{rc,
                             p.epsilon,
                             p.sigma,

--- a/src/mirheo/core/interactions/pairwise/kernels/stress_wrapper.h
+++ b/src/mirheo/core/interactions/pairwise/kernels/stress_wrapper.h
@@ -77,8 +77,8 @@ public:
     {}
 
     /// Generic constructor
-    PairwiseStressWrapper(real rc, const ParamsType& p, real dt, long seed=42424242) :
-        BasicPairwiseForce(rc, p, dt, seed),
+    PairwiseStressWrapper(real rc, const ParamsType& p, long seed=42424242) :
+        BasicPairwiseForce(rc, p, seed),
         basicForceWrapperHandler_ {HandlerType{BasicPairwiseForce::handler()}}
     {}
 

--- a/src/mirheo/core/interactions/pairwise/pairwise.h
+++ b/src/mirheo/core/interactions/pairwise/pairwise.h
@@ -44,7 +44,7 @@ public:
     PairwiseInteraction(const MirState *state, const std::string& name, real rc,
                         KernelParams pairParams, long seed = 42424242) :
         BasePairwiseInteraction(state, name, rc),
-        defaultPair_{rc, pairParams, state->dt, seed},
+        defaultPair_{rc, pairParams, seed},
         _pairParams{pairParams}
     {}
 
@@ -70,7 +70,7 @@ public:
             intMap_.emplace(
                     std::make_pair(loader.load<std::string>(mapArray[i]),
                                    loader.load<std::string>(mapArray[i + 1])),
-                    Kernel{PairwiseKernel{rc_, params, state->dt, seed}, params});
+                    Kernel{PairwiseKernel{rc_, params, seed}, params});
         }
     }
 
@@ -162,7 +162,7 @@ public:
         ParametersWrap desc(mapParams);
         auto params = _pairParams;
         factory_helper::readSpecificParams(params, desc);
-        PairwiseKernel kernel {rc_, params, getState()->dt};
+        PairwiseKernel kernel {rc_, params};
         _setSpecificPair(pv1name, pv2name, kernel, params);
     }
 

--- a/src/mirheo/core/mirheo.cpp
+++ b/src/mirheo/core/mirheo.cpp
@@ -102,8 +102,8 @@ void Mirheo::init(int3 nranks3D, real3 globalDomainSize, LogInfo logInfo,
         selectIntraNodeGPU(comm_);
 
         createCartComm(comm_, nranks3D, &cartComm_);
-        state_ = std::make_shared<MirState> (createDomainInfo(cartComm_, globalDomainSize), -1,
-                                             units, stateConfig);
+        state_ = std::make_shared<MirState> (createDomainInfo(cartComm_, globalDomainSize),
+                                             MirState::InvalidDt, units, stateConfig);
         sim_ = std::make_unique<Simulation> (cartComm_, MPI_COMM_NULL, getState(),
                                             checkpointInfo, gpuAwareMPI);
         computeTask_ = 0;
@@ -131,8 +131,8 @@ void Mirheo::init(int3 nranks3D, real3 globalDomainSize, LogInfo logInfo,
         selectIntraNodeGPU(compComm_);
 
         createCartComm(compComm_, nranks3D, &cartComm_);
-        state_ = std::make_shared<MirState> (createDomainInfo(cartComm_, globalDomainSize), -1,
-                                             units, stateConfig);
+        state_ = std::make_shared<MirState> (createDomainInfo(cartComm_, globalDomainSize),
+                                             MirState::InvalidDt, units, stateConfig);
         sim_ = std::make_unique<Simulation> (cartComm_, interComm_, getState(),
                                             checkpointInfo, gpuAwareMPI);
     }
@@ -677,7 +677,7 @@ void Mirheo::run(int nsteps, real dt)
     struct DtGuard {
         ~DtGuard() noexcept {
             if (state)
-                state->setDt(-1);  // Negative dt marks it as unavailable.
+                state->setDt(MirState::InvalidDt);
         }
 
         MirState *state;

--- a/src/mirheo/core/mirheo_state.h
+++ b/src/mirheo/core/mirheo_state.h
@@ -82,6 +82,7 @@ struct TypeLoadSave<UnitConversion>
 class MirState
 {
 public:
+    static constexpr real InvalidDt = -1;
     using TimeType = double; ///< type used to store time information
     using StepType = long long; ///< type to store time step information
 
@@ -91,7 +92,7 @@ public:
         \param [in] units Conversion factors from Mirheo to SI units
         \param [in] state If not \c nullptr, will set the current time info from snapshot info
     */
-    MirState(DomainInfo domain, real dt = -1, UnitConversion units = UnitConversion{}, const ConfigValue *state = nullptr);
+    MirState(DomainInfo domain, real dt = InvalidDt, UnitConversion units = UnitConversion{}, const ConfigValue *state = nullptr);
 
 
     /** Save internal state to file

--- a/src/mirheo/core/mirheo_state.h
+++ b/src/mirheo/core/mirheo_state.h
@@ -4,7 +4,6 @@
 #include "domain.h"
 #include "utils/common.h"
 
-#include <memory>
 #include <mpi.h>
 #include <string>
 
@@ -92,7 +91,7 @@ public:
         \param [in] units Conversion factors from Mirheo to SI units
         \param [in] state If not \c nullptr, will set the current time info from snapshot info
     */
-    MirState(DomainInfo domain, real dt, UnitConversion units, const ConfigValue *state = nullptr);
+    MirState(DomainInfo domain, real dt = -1, UnitConversion units = UnitConversion{}, const ConfigValue *state = nullptr);
 
 
     /** Save internal state to file
@@ -107,13 +106,33 @@ public:
      */
     void restart(MPI_Comm comm, std::string path);
 
+    /** Get the current time step dt. Accessible only during Mirheo::run. */
+    real getDt() const {
+        if (dt_ < 0)
+            _dieInvalidDt();
+        return dt_;
+    }
+
+    /** Set the time step dt.
+        \param [in] dt time step duration
+     */
+    void setDt(real dt) noexcept {
+        dt_ = dt;
+    }
+
 public:
     DomainInfo domain; ///< Global DomainInfo
 
-    real dt; ///< time step
     TimeType currentTime; ///< Current simulation time
     StepType currentStep; ///< Current simulation step
     UnitConversion units; ///< Conversion between Mirheo and SI units (optional).
+
+private:
+    void _dieInvalidDt [[noreturn]]() const; // To avoid including logger here.
+
+    real dt_; ///< time step
+
+    friend TypeLoadSave<MirState>;
 };
 
 /// template specialization struct to implement snapshot save

--- a/src/mirheo/core/simulation.cpp
+++ b/src/mirheo/core/simulation.cpp
@@ -238,7 +238,7 @@ int3 Simulation::getNRanks3D() const
 
 real Simulation::getCurrentDt() const
 {
-    return state_->dt;
+    return state_->getDt();
 }
 
 real Simulation::getCurrentTime() const
@@ -1246,7 +1246,7 @@ void Simulation::run(int nsteps)
 
         scheduler_->run();
 
-        state_->currentTime += state_->dt;
+        state_->currentTime += state_->getDt();
     }
 
     // Finish the redistribution by rebuilding the cell-lists

--- a/src/mirheo/core/walls/simple_stationary_wall.cu
+++ b/src/mirheo/core/walls/simple_stationary_wall.cu
@@ -456,7 +456,7 @@ void SimpleStationaryWall<InsideWallChecker>::removeInner(ParticleVector *pv)
 template<class InsideWallChecker>
 void SimpleStationaryWall<InsideWallChecker>::bounce(cudaStream_t stream)
 {
-    const real dt = this->getState()->dt;
+    const real dt = this->getState()->getDt();
 
     bounceForce_.clear(stream);
 

--- a/src/mirheo/core/walls/wall_with_velocity.cu
+++ b/src/mirheo/core/walls/wall_with_velocity.cu
@@ -86,7 +86,7 @@ template<class InsideWallChecker, class VelocityField>
 void WallWithVelocity<InsideWallChecker, VelocityField>::bounce(cudaStream_t stream)
 {
     real t  = this->getState()->currentTime;
-    real dt = this->getState()->dt;
+    real dt = this->getState()->getDt();
 
     velField_.setup(t, this->getState()->domain);
     this->bounceForce_.clear(stream);

--- a/src/mirheo/plugins/berendsen_thermostat.cu
+++ b/src/mirheo/plugins/berendsen_thermostat.cu
@@ -121,7 +121,7 @@ void BerendsenThermostatPlugin::afterIntegration(cudaStream_t stream)
     // E_kinetic == 1/2 * k_B * T * <number of degrees of freedom>
     real currentkBT = kineticEnergy * 2 / (3 * totalParticles);
     real lambda = increaseIfLower_ || currentkBT > kBT_
-            ? sqrt(1 + getState()->dt / tau_ * (kBT_ / currentkBT - 1))
+            ? sqrt(1 + getState()->getDt() / tau_ * (kBT_ / currentkBT - 1))
             : 1.0_r;
 
     // Update local particles.

--- a/src/mirheo/plugins/outlet.cu
+++ b/src/mirheo/plugins/outlet.cu
@@ -268,7 +268,7 @@ void RateOutletPlugin::beforeCellLists(cudaStream_t stream)
         PVview view(pv, pv->local());
 
         const real seed = udistr_(gen_);
-        const real QTimesdt = rate_ * getState()->dt * view.invMass;
+        const real QTimesdt = rate_ * getState()->getDt() * view.invMass;
 
         auto isInsideFunc = [field = outletRegion_->handler()] __device__ (const real3& r)
         {

--- a/src/mirheo/plugins/particle_checker.cu
+++ b/src/mirheo/plugins/particle_checker.cu
@@ -203,7 +203,7 @@ void ParticleCheckerPlugin::afterIntegration(cudaStream_t stream)
 
     constexpr int nthreads = 128;
 
-    const real dt     = getState()->dt;
+    const real dt     = getState()->getDt();
     const real dtInv  = 1.0_r / math::max(1e-6_r, dt);
     const auto domain = getState()->domain;
 

--- a/src/mirheo/plugins/pin_object.cu
+++ b/src/mirheo/plugins/pin_object.cu
@@ -204,7 +204,7 @@ void PinObjectPlugin::afterIntegration(cudaStream_t stream)
         SAFE_KERNEL_LAUNCH(
                 pin_object_kernels::restrictRigidMotion,
                 getNblocks(view.nObjects, nthreads), nthreads, 0, stream,
-                view, translation_, rotation_, getState()->dt,
+                view, translation_, rotation_, getState()->getDt(),
                 forces_.devPtr(), torques_.devPtr() );
     }
 }

--- a/src/mirheo/plugins/velocity_inlet.cu
+++ b/src/mirheo/plugins/velocity_inlet.cu
@@ -211,7 +211,7 @@ void VelocityInletPlugin::beforeCellLists(cudaStream_t stream)
     SAFE_KERNEL_LAUNCH(
         velocity_inlet_kernels::countFromCumulativeFluxes,
         getNblocks(nTriangles, nthreads), nthreads, 0, stream,
-        nTriangles, getState()->dt, numberDensity_, localFluxes_.devPtr(),
+        nTriangles, getState()->getDt(), numberDensity_, localFluxes_.devPtr(),
         cumulativeFluxes_.devPtr(), nNewParticles_.devPtr(), workQueue_.devPtr());
 
 

--- a/tests/bindings/obj_rod.py
+++ b/tests/bindings/obj_rod.py
@@ -21,7 +21,7 @@ L = 14.0
 num_segments = 10
 mass = 1.0
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 # rod
 
@@ -111,7 +111,7 @@ if args.vis:
     u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_ell, dump_every, path="ply/"))
 
 
-u.run(int (t_end / dt))
+u.run(int(t_end / dt), dt=dt)
 
 if pv_rod is not None:
     pos_rod = pv_rod.getCoordinates()

--- a/tests/bounce/membrane/mesh.py
+++ b/tests/bounce/membrane/mesh.py
@@ -22,7 +22,7 @@ if args.subStep:
 ranks  = (1, 1, 1)
 domain = (8, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 nparts = 1000
 np.random.seed(42)
@@ -78,7 +78,7 @@ if args.vis:
 
 tend = int(5.0 / dt)
 
-u.run(tend)
+u.run(tend, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/bounce/rigid/capsule.py
+++ b/tests/bounce/rigid/capsule.py
@@ -17,7 +17,7 @@ length = 5.0
 
 dt   = 0.001
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 nparts = 100
 np.random.seed(42)
@@ -70,7 +70,7 @@ if args.vis:
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("rigStats", ov_rig, dump_every, path="stats"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 # nTEST: bounce.rigid.capsule
 # set -eu

--- a/tests/bounce/rigid/cylinder.py
+++ b/tests/bounce/rigid/cylinder.py
@@ -17,7 +17,7 @@ length = 5.0
 
 dt   = 0.001
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 nparts = 100
 np.random.seed(42)
@@ -68,7 +68,7 @@ if args.vis:
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("rigStats", ov_rig, dump_every, path="stats"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 # nTEST: bounce.rigid.cylinder
 # set -eu

--- a/tests/bounce/rigid/ellipsoid.py
+++ b/tests/bounce/rigid/ellipsoid.py
@@ -16,7 +16,7 @@ domain = [8., 8., 8.]
 
 dt   = 0.001
 
-u = mir.Mirheo(args.ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(args.ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 nparts = 100
 np.random.seed(42)
@@ -72,7 +72,7 @@ if args.vis:
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("rigStats", pv_rig, dump_every, path="stats"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 # nTEST: bounce.rigid.ellipsoid
 # set -eu

--- a/tests/bounce/rigid/mesh.py
+++ b/tests/bounce/rigid/mesh.py
@@ -15,7 +15,7 @@ domain = [8., 8., 8.]
 
 dt   = 0.001
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 nparts = 100
 np.random.seed(42)
@@ -67,7 +67,7 @@ if args.vis:
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("rigStats", ov=pv_rig, dump_every=dump_every, path="stats"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 
 # nTEST: bounce.rigid.mesh

--- a/tests/bounce/rod/main.py
+++ b/tests/bounce/rod/main.py
@@ -19,7 +19,7 @@ num_segments = 4
 mass_sol = 0.1
 mass_rod = 100.0
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 nparts = 1000
 np.random.seed(42)
@@ -65,7 +65,7 @@ if args.vis:
 
 tend = int(5.0 / dt)
 
-u.run(tend)
+u.run(tend, dt=dt)
 
 if pv_rod is not None:
     rod_pos = pv_rod.getCoordinates()

--- a/tests/clist/rest.py
+++ b/tests/clist/rest.py
@@ -15,7 +15,7 @@ domain = (6, 6, 6)
 rc_fake = 1.0
 rc = 0.75
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=4)
@@ -38,7 +38,7 @@ dump_every = 100
 
 u.registerPlugins(mir.Plugins.createStats('stats', "stats", dump_every))
 
-u.run(501)
+u.run(501, dt=dt)
 
 # nTEST: clist.primary.rc
 # cd clist

--- a/tests/contact/ellipsoids.dp.py
+++ b/tests/contact/ellipsoids.dp.py
@@ -19,7 +19,7 @@ density = args.density
 ranks  = (1, 1, 1)
 domain = (16, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
 ic_sol = mir.InitialConditions.Uniform(density)
@@ -64,7 +64,7 @@ if args.bounce_back:
 #u.registerPlugins(mir.Plugins.createDumpParticles('partDump', pv_ell, 500, [], "h5/ellbb"))
 u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov=pv_ell, dump_every=500, path="stats"))
 
-u.run(10000)
+u.run(10000, dt=dt)
 
 # nTEST: contact.rigid.ellipsoids
 # set -eu

--- a/tests/contact/membranes.dp.py
+++ b/tests/contact/membranes.dp.py
@@ -21,7 +21,7 @@ if args.substep:
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
 ic_sol = mir.InitialConditions.Uniform(number_density=8)
@@ -72,7 +72,7 @@ u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, (int)(0.15/dt)
 
 
 nsteps = (int) (tend/dt)
-u.run(nsteps)
+u.run(nsteps, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/contact/mix.dp.py
+++ b/tests/contact/mix.dp.py
@@ -26,7 +26,7 @@ if args.substep:
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
 ic_sol = mir.InitialConditions.Uniform(number_density=args.density)
@@ -104,7 +104,7 @@ if debug:
     u.registerPlugins(mir.Plugins.createDumpXYZ('xyz', pv_ell, dump_every, "xyz/"))
 
 nsteps = (int) (tend/dt)
-u.run(nsteps)
+u.run(nsteps, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/doc_scripts/basic.py
+++ b/tests/doc_scripts/basic.py
@@ -14,7 +14,7 @@ domain = (8, 16, 30)
 f = 1
 
 # Create the coordinator, this should precede any other setup from mirheo package
-u = mir.Mirheo(ranks, domain, dt, debug_level=2, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=2, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)   # Create a simple particle vector
 ic = mir.InitialConditions.Uniform(number_density=8)      # Specify uniform random initial conditions
@@ -46,4 +46,4 @@ u.registerPlugins(mir.Plugins.createStats('stats', every=500))
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
 # Run 5002 time-steps
-u.run(5002)
+u.run(5002, dt=dt)

--- a/tests/doc_scripts/generate_frozen_rigid.py
+++ b/tests/doc_scripts/generate_frozen_rigid.py
@@ -23,7 +23,7 @@ inertia = [row[i] for i, row in enumerate(m.moment_inertia)]
 ranks  = (1, 1, 1)
 domain = (16, 16, 16)
     
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 dpd = mir.Interactions.Pairwise('dpd', rc, kind="DPD", a=10.0, gamma=10.0, kBT=0.5, power=0.5)
 vv  = mir.Integrators.VelocityVerlet('vv')
@@ -46,7 +46,7 @@ fake_ic = mir.InitialConditions.Rigid(com_q, coords)
 belonging_checker = mir.BelongingCheckers.Mesh("mesh_checker")
 
 # similarly to wall creation, we freeze particles inside a rigid object
-pv_rigid = u.makeFrozenRigidParticles(belonging_checker, fake_ov, fake_ic, [dpd], vv, number_density, mass, niter)
+pv_rigid = u.makeFrozenRigidParticles(belonging_checker, fake_ov, fake_ic, [dpd], vv, number_density, mass, dt=dt, nsteps=niter)
 
 if u.isMasterTask():
     coords = pv_rigid.getCoordinates()

--- a/tests/doc_scripts/hello.py
+++ b/tests/doc_scripts/hello.py
@@ -8,6 +8,6 @@ ranks  = (1, 1, 1)          # number of ranks in x, y, z directions
 domain = (32.0, 16.0, 16.0) # domain size in x, y, z directions
 
 # create the coordinator
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
-u.run(100) # Run 100 time-steps
+u.run(100, dt=dt) # Run 100 time-steps

--- a/tests/doc_scripts/membrane.py
+++ b/tests/doc_scripts/membrane.py
@@ -7,7 +7,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 12, 12)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 # we need to first create a mesh before initializing the membrane vector
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
@@ -54,4 +54,4 @@ u.setInteraction(int_rbc, pv_rbc, pv_rbc)
 # dump the mesh every 50 steps in ply format to the folder 'ply/'
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, 50, "ply/"))
 
-u.run(5002)
+u.run(5002, dt=dt)

--- a/tests/doc_scripts/membranes_solvents.py
+++ b/tests/doc_scripts/membranes_solvents.py
@@ -9,7 +9,7 @@ number_density = 8.0
 ranks  = (1, 1, 1)
 domain = (16.0, 16.0, 16.0)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 # create the particle vectors
 #############################
@@ -120,4 +120,4 @@ u.registerPlugins(mir.Plugins.createDumpParticles('part_dump_inner', pv_inner, d
 u.registerPlugins(mir.Plugins.createDumpParticles('part_dump_outer', pv_outer, dump_every, [], 'h5/outer-'))
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, dump_every, "ply/"))
 
-u.run(5002)
+u.run(5002, dt=dt)

--- a/tests/doc_scripts/rest.py
+++ b/tests/doc_scripts/rest.py
@@ -9,7 +9,7 @@ number_density = 8.0
 ranks  = (1, 1, 1)
 domain = (16.0, 16.0, 16.0)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1.0) # Create a simple Particle Vector (PV) named 'pv'
 ic = mir.InitialConditions.Uniform(number_density)        # Specify uniform random initial conditions
@@ -36,4 +36,4 @@ u.registerPlugins(mir.Plugins.createStats('stats', every=500))
 dump_every = 500
 u.registerPlugins(mir.Plugins.createDumpParticles('part_dump', pv, dump_every, [], 'h5/solvent_particles-'))
 
-u.run(5002)
+u.run(5002, dt=dt)

--- a/tests/doc_scripts/rigid_suspension.py
+++ b/tests/doc_scripts/rigid_suspension.py
@@ -15,7 +15,7 @@ inertia = [row[i] for i, row in enumerate(m.moment_inertia)]
 ranks  = (1, 1, 1)
 domain = (16, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_solvent = mir.ParticleVectors.ParticleVector('solvent', mass)
 ic_solvent = mir.InitialConditions.Uniform(number_density)
@@ -66,4 +66,4 @@ u.setBouncer(bb, pv_rigid, pv_solvent)
 # dump the mesh every 200 steps in ply format to the folder 'ply/'
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rigid, 200, "ply/"))
 
-u.run(10000)
+u.run(10000, dt=dt)

--- a/tests/doc_scripts/walls.py
+++ b/tests/doc_scripts/walls.py
@@ -8,7 +8,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (16.0, 16.0, 16.0)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv  = mir.ParticleVectors.ParticleVector('pv', mass = 1.0)
 ic  = mir.InitialConditions.Uniform(number_density)
@@ -33,7 +33,7 @@ u.registerWall(wall) # register the wall in the coordinator
 # the following command is running a simulation of a solvent with given density equilibrating with dpd interactions and vv integrator
 # for 1000 steps.
 # It then selects the frozen particles according to the walls geometry, register and returns the newly created particle vector.
-pv_frozen = u.makeFrozenWallParticles(pvName="wall", walls=[wall], interactions=[dpd], integrator=vv, number_density=number_density)
+pv_frozen = u.makeFrozenWallParticles(pvName="wall", walls=[wall], interactions=[dpd], integrator=vv, number_density=number_density, dt=dt)
 
 # set the wall for pv
 # this is required for non-penetrability of the solvent thanks to bounce-back
@@ -58,4 +58,4 @@ u.registerPlugins(mir.Plugins.createDumpParticles('part_dump_wall', pv_frozen, d
 # the dumped file is a grid with spacings h containing the SDF values 
 u.dumpWalls2XDMF([wall], h = (0.5, 0.5, 0.5), filename = 'h5/wall')
 
-u.run(5002)
+u.run(5002, dt=dt)

--- a/tests/dump/graph.full.py
+++ b/tests/dump/graph.full.py
@@ -2,12 +2,10 @@
 
 import mirheo as mir
 
-dt = 0.001
-
 ranks  = (1, 1, 1)
 domain = (4, 4, 4)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 u.save_dependency_graph_graphml("tasks.full", current=False)
 

--- a/tests/dump/h5.mesh.py
+++ b/tests/dump/h5.mesh.py
@@ -10,7 +10,7 @@ args = parser.parse_args()
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 m = trimesh.load(args.mesh);
 mesh = mir.ParticleVectors.MembraneMesh(m.vertices.tolist(), m.faces.tolist())
@@ -22,7 +22,7 @@ u.registerParticleVector(pv_rbc, ic_rbc)
 dumpEvery = 1
 u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh('partDump', pv_rbc, dumpEvery, [], 'h5/rbc-'))
 
-u.run(2)
+u.run(2, dt=0)
 
 # TEST: dump.h5.mesh
 # cd dump

--- a/tests/dump/h5.mesh.sdf.py
+++ b/tests/dump/h5.mesh.sdf.py
@@ -12,7 +12,7 @@ domain = (12, 8, 10)
 
 rc=1.0
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 m = trimesh.load(args.mesh);
 mesh = mir.ParticleVectors.MembraneMesh(m.vertices.tolist(), m.faces.tolist())
@@ -32,7 +32,7 @@ u.registerPlugins(mir.Plugins.createWallRepulsion("wallRepulsion", pv_rbc, plate
 dump_every = 1
 u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh('partDump', pv_rbc, dump_every, ["sdf"], 'h5/rbc-'))
 
-u.run(2)
+u.run(2, dt=0)
 
 # nTEST: dump.h5.mesh.sdf
 # cd dump

--- a/tests/dump/h5.parts.mpi.py
+++ b/tests/dump/h5.parts.mpi.py
@@ -5,7 +5,7 @@ import mirheo as mir
 ranks  = (2, 1, 1)
 domain = (4, 2, 2)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pos = [[1., 0.25, 0.5],
        [1., 0.50, 0.5],
@@ -22,7 +22,7 @@ dump_every = 1
 
 u.registerPlugins(mir.Plugins.createDumpParticles('partDump', pv, dump_every, [], 'h5/solvent_particles-'))
 
-u.run(1)
+u.run(1, dt=0)
 
 # TEST: dump.h5.parts.mpi.2nodes
 # cd dump

--- a/tests/dump/h5.parts.py
+++ b/tests/dump/h5.parts.py
@@ -10,7 +10,7 @@ args = parser.parse_args()
 ranks  = (1, 1, 1)
 domain = (2, 2, 4)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash = True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash = True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(args.density)
@@ -20,7 +20,7 @@ dump_every = 1
 
 u.registerPlugins(mir.Plugins.createDumpParticles('partDump', pv, dump_every, [], 'h5/solvent_particles-'))
 
-u.run(1)
+u.run(1, dt=0)
 
 # TEST: dump.h5.parts
 # cd dump

--- a/tests/dump/h5.py
+++ b/tests/dump/h5.py
@@ -9,7 +9,7 @@ args = parser.parse_args()
 
 domain = (8, 16, 4)
 
-u = mir.Mirheo(args.ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(args.ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=3)
@@ -21,7 +21,7 @@ bin_size     = (1., 1., 1.)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(2)
+u.run(2, dt=0)
 
 # TEST: dump.h5
 # cd dump

--- a/tests/dump/mesh.py
+++ b/tests/dump/mesh.py
@@ -16,7 +16,7 @@ off    = "rbc_mesh.off"
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 if args.readFrom == "off":
     mesh = mir.ParticleVectors.MembraneMesh(off)
@@ -30,7 +30,7 @@ u.registerParticleVector(pv_rbc, ic_rbc)
 
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, 1, path))
 
-u.run(3)
+u.run(3, dt=0)
 
 if u.isMasterTask():
     mesh = trimesh.load(path + pvname + "_00000.ply")

--- a/tests/dump/ov_stats.py
+++ b/tests/dump/ov_stats.py
@@ -5,7 +5,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = (8, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mass = 1.0
 
@@ -19,7 +19,7 @@ u.registerParticleVector(ov, ic)
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov, dump_every=1, path="stats"))
 
-u.run(2)
+u.run(2, dt=0)
 
 # TEST: dump.ov_stats
 # cd dump

--- a/tests/dump/rov_stats.py
+++ b/tests/dump/rov_stats.py
@@ -5,7 +5,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = (8, 8, 16)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 axes = (1.0, 2.0, 3.0)
 
@@ -19,7 +19,7 @@ u.registerParticleVector(ov, ic)
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov, dump_every=1, path="stats"))
 
-u.run(2)
+u.run(2, dt=0)
 
 # TEST: dump.rov_stats
 # cd dump

--- a/tests/dump/stats.py
+++ b/tests/dump/stats.py
@@ -7,7 +7,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (8, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=10)
@@ -23,7 +23,7 @@ u.setIntegrator(vv, pv)
 
 u.registerPlugins(mir.Plugins.createStats('stats', "stats", 200))
 
-u.run(2000)
+u.run(2000, dt=dt)
 
 # nTEST: dump.stats
 # cd dump

--- a/tests/dump/xyz.py
+++ b/tests/dump/xyz.py
@@ -5,7 +5,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = (8, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=2)
@@ -13,7 +13,7 @@ u.registerParticleVector(pv, ic)
 
 u.registerPlugins(mir.Plugins.createDumpXYZ('xyz', pv, 1, "xyz"))
 
-u.run(2)
+u.run(2, dt=0)
 
 # TEST: dump.xyz
 # cd dump

--- a/tests/flow/double_poiseuille.2pvs.py
+++ b/tests/flow/double_poiseuille.2pvs.py
@@ -9,7 +9,7 @@ ranks  = (1, 1, 1)
 domain = (16, 16, 16)
 a = 1
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv1 = mir.ParticleVectors.ParticleVector('pv1', mass = 1)
 pv2 = mir.ParticleVectors.ParticleVector('pv2', mass = 1)
@@ -34,7 +34,7 @@ bin_size     = (1., 1., 1.)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv1, pv2], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 # nTEST: flow.double_poiseuille.2pvs
 # cd flow

--- a/tests/flow/double_poiseuille.py
+++ b/tests/flow/double_poiseuille.py
@@ -8,7 +8,7 @@ ranks  = (1, 1, 1)
 domain = (16, 16, 16)
 a = 1
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=4)
@@ -28,7 +28,7 @@ bin_size     = (1., 1., 1.)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 # nTEST: flow.double_poiseuille
 # cd flow

--- a/tests/flow/poiseuille.py
+++ b/tests/flow/poiseuille.py
@@ -10,7 +10,7 @@ vtarget = (1.0, 0, 0)
 
 density = 10
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(density)
@@ -25,7 +25,7 @@ u.registerWall(plate_lo, 0)
 u.registerWall(plate_hi, 0)
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen = u.makeFrozenWallParticles(pvName="frozen", walls=[plate_lo, plate_hi], interactions=[dpd], integrator=vv, number_density=density)
+frozen = u.makeFrozenWallParticles(pvName="frozen", walls=[plate_lo, plate_hi], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(plate_lo, pv)
 u.setWall(plate_hi, pv)
@@ -54,7 +54,7 @@ vc_dump_every = 500
 u.registerPlugins(mir.Plugins.createVelocityControl("vc", "vcont", [pv], (0, 0, 0), domain,
                                                     vc_sample_every, vc_tune_every, vc_dump_every, vtarget, Kp, Ki, Kd))
 
-u.run(20002)
+u.run(20002, dt=dt)
 
 # nTEST: flow.poiseuille
 # cd flow

--- a/tests/flow/rest.py
+++ b/tests/flow/rest.py
@@ -10,7 +10,7 @@ domain = (12, 8, 10)
 rc = 1.0
 num_density = 8
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(num_density)
@@ -26,7 +26,7 @@ u.setIntegrator(vv, pv)
 
 u.registerPlugins(mir.Plugins.createStats('stats', "stats", 1000))
 
-u.run(5001)
+u.run(5001, dt=dt)
 
 # nTEST: flow.rest
 # cd flow

--- a/tests/flow/uniform_vel.py
+++ b/tests/flow/uniform_vel.py
@@ -8,7 +8,7 @@ ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 vtarget = (1.0, 0, 0)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=2)
@@ -30,7 +30,7 @@ Kd = 8.0 * factor
 u.registerPlugins(mir.Plugins.createVelocityControl("vc", "vcont.csv", [pv], (0, 0, 0), domain, 5, 5, 50, vtarget, Kp, Ki, Kd))
 u.registerPlugins(mir.Plugins.createStats('stats', "stats.csv", 1000))
 
-u.run(5001)
+u.run(5001, dt=dt)
 
 # nTEST: flow.uniform_vel
 # cd flow

--- a/tests/fsi/ellipsoid.dp.py
+++ b/tests/fsi/ellipsoid.dp.py
@@ -19,7 +19,7 @@ density = args.density
 ranks  = (1, 1, 1)
 domain = (16, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
 ic_sol = mir.InitialConditions.Uniform(density)
@@ -58,7 +58,7 @@ if args.bounce_back:
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov=pv_ell, dump_every=500, path="stats"))
 
-u.run(10000)
+u.run(10000, dt=dt)
 
 
 # nTEST: fsi.rigid.ellipsoid

--- a/tests/fsi/membrane.dp.py
+++ b/tests/fsi/membrane.dp.py
@@ -22,7 +22,7 @@ if args.substep:
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
 ic_sol = mir.InitialConditions.Uniform(number_density=8)
@@ -60,7 +60,7 @@ u.registerIntegrator(vv_dp)
 u.setIntegrator(vv_dp, pv_sol)
 
 nsteps = (int) (tend/dt)
-u.run(nsteps)
+u.run(nsteps, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/ic/filtered.py
+++ b/tests/ic/filtered.py
@@ -12,7 +12,7 @@ ranks  = (1, 1, 1)
 domain = [4., 4., 4.]
 density = 8
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 if args.filter == "half":
     def my_filter(r):
@@ -27,7 +27,7 @@ pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.UniformFiltered(density, my_filter)
 u.registerParticleVector(pv=pv, ic=ic)
 
-u.run(2)
+u.run(2, dt=0)
 
 if pv:
     icpos = pv.getCoordinates()

--- a/tests/ic/from_array.py
+++ b/tests/ic/from_array.py
@@ -6,7 +6,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = [4., 6., 8.]
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 
@@ -17,7 +17,7 @@ vel = [[a*v[0], a*v[1], a*v[2]] for a in [0.1, 0.5, 0.8, 1.5]]
 ic = mir.InitialConditions.FromArray(pos, vel)
 u.registerParticleVector(pv, ic)
 
-u.run(2)
+u.run(2, dt=0)
 
 if pv:
     icpos = pv.getCoordinates()

--- a/tests/ic/rigid.py
+++ b/tests/ic/rigid.py
@@ -6,7 +6,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = [4., 6., 8.]
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 a=(0.1, 0.2, 0.3)
 
@@ -26,7 +26,7 @@ pv = mir.ParticleVectors.RigidEllipsoidVector('ellipsoid', mass=1, object_size=l
 ic = mir.InitialConditions.Rigid(com_q, coords)
 u.registerParticleVector(pv, ic)
 
-u.run(2)
+u.run(2, dt=0)
 
 if pv:
     icpos = pv.getCoordinates()

--- a/tests/ic/rod.py
+++ b/tests/ic/rod.py
@@ -11,7 +11,7 @@ args = parser.parse_args()
 ranks  = (1, 1, 1)
 domain = [16, 16, 16]
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[ 1., 0., 0.,    1.0, 0.0, 0.0, 0.0],
          [ 5., 0., 0.,    1.0, 2.0, 0.0, 0.0],
@@ -42,7 +42,7 @@ u.registerParticleVector(rv, ic)
 dump_every = 1
 u.registerPlugins(mir.Plugins.createDumpParticles('rod_dump', rv, dump_every, [], 'h5/rod_particles-'))
 
-u.run(2)
+u.run(2, dt=0)
 
 if rv:
     icpos = rv.getCoordinates()

--- a/tests/ic/sphere.py
+++ b/tests/ic/sphere.py
@@ -7,13 +7,13 @@ ranks  = (1, 1, 1)
 domain = [4., 4., 4.]
 density = 8
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.UniformSphere(number_density=density, center=(2., 2., 2.), radius=2.0, inside=True)
 u.registerParticleVector(pv, ic)
 
-u.run(2)
+u.run(2, dt=0)
 
 if pv:
     icpos = pv.getCoordinates()

--- a/tests/ic/uniform.py
+++ b/tests/ic/uniform.py
@@ -12,13 +12,13 @@ ranks  = (1, 1, 1)
 domain = args.domain
 density = 8
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(density)
 u.registerParticleVector(pv, ic)
 
-u.run(2)
+u.run(2, dt=0)
 
 if pv:
     icpos = pv.getCoordinates()

--- a/tests/log/silent.py
+++ b/tests/log/silent.py
@@ -10,7 +10,7 @@ domain = (12, 8, 10)
 rc = 1.0
 density = 8
 
-u = mir.Mirheo(ranks, domain, dt, no_splash=True, debug_level=0, log_filename='stdout')
+u = mir.Mirheo(ranks, domain, no_splash=True, debug_level=0, log_filename='stdout')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(density)
@@ -24,7 +24,7 @@ vv = mir.Integrators.VelocityVerlet('vv')
 u.registerIntegrator(vv)
 u.setIntegrator(vv, pv)
 
-u.run(50)
+u.run(50, dt=dt)
 
 # TEST: log.silent
 # cd log

--- a/tests/md/berendsen_thermostat.py
+++ b/tests/md/berendsen_thermostat.py
@@ -8,18 +8,18 @@ Test that running with 1 and with 2 ranks produces the same result.
 import mirheo as mir
 import sys
 
+# Units. 1 == Mirheo unit.
+nm = 1
+fs = 1
+kg = 1e27
+K = 1
+
+m = 1e9
+s = 1e15
+J = kg * m ** 2 / s ** 2
+
 
 def init():
-    # Units. 1 == Mirheo unit.
-    nm = 1
-    fs = 1
-    kg = 1e27
-    K = 1
-
-    m = 1e9
-    s = 1e15
-    J = kg * m ** 2 / s ** 2
-
     # Argon model and system properties.
     epsilon = 996. * J / 6.022e23
     sigma = 0.340 * nm
@@ -28,7 +28,7 @@ def init():
     number_density = 0.6 / sigma ** 3
     domain = (10 * nm, 8 * nm, 6 * nm)
 
-    u = mir.Mirheo((1, 1, 1), domain, dt=1.0 * fs, debug_level=3, log_filename='log',
+    u = mir.Mirheo((1, 1, 1), domain, debug_level=3, log_filename='log',
                    no_splash=True, units=mir.UnitConversion(1 / m, 1 / s, 1 / kg))
 
     pv = mir.ParticleVectors.ParticleVector('pv', mass=mass)
@@ -48,13 +48,13 @@ def init():
     u.registerPlugins(mir.Plugins.createBerendsenThermostat('thermostat', [pv], T=215 * K, tau=50.0 * fs))
     u.registerPlugins(mir.Plugins.createStats('stats', every=50))
 
-    u.run(0)
+    u.run(0, dt=1.0 * fs)
     u.saveSnapshot('snapshot')
 
 
 def run(nranks):
     u = mir.Mirheo(nranks, snapshot='snapshot', debug_level=3, log_filename='log', no_splash=True)
-    u.run(402)
+    u.run(402, dt=1.0 * fs)
 
 
 if sys.argv[1] == 'init':

--- a/tests/md/minimization.py
+++ b/tests/md/minimization.py
@@ -26,7 +26,7 @@ max_displacement = 0.001 * nm
 number_density = 0.6 / sigma ** 3
 domain = (12 * nm, 10 * nm, 8 * nm)
 
-u = mir.Mirheo((1, 1, 1), domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo((1, 1, 1), domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass=mass)
 ic = mir.InitialConditions.Uniform(number_density=number_density)
@@ -44,7 +44,7 @@ u.registerPlugins(mir.Plugins.createForceSaver('forceSaver', pv))
 u.registerPlugins(mir.Plugins.createDumpParticles(
         'meshdump', pv, 10, ['forces'], 'h5/pv-'))
 
-u.run(101)
+u.run(101, dt=dt)
 
 if MPI.COMM_WORLD.rank == 0:
     for i in range(10):

--- a/tests/mdpd/density.py
+++ b/tests/mdpd/density.py
@@ -7,7 +7,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (9, 9, 9)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=10)
@@ -39,7 +39,7 @@ grid_bin_size     = (1., 1., 1.)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], grid_sample_every, grid_dump_every, grid_bin_size, [density_channel], 'h5/solvent-'))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 # nTEST: mdpd.density
 # cd mdpd

--- a/tests/mdpd/drop.py
+++ b/tests/mdpd/drop.py
@@ -7,7 +7,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (16, 16, 16)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 R = 6.0
 density = 5.0
@@ -39,7 +39,7 @@ dump_every = 5000
 bin_size = (0.5, 0.5, 0.5)
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, [], 'h5/solvent-'))
 
-u.run(5001)
+u.run(5001, dt=dt)
 
 del(u)
 

--- a/tests/mdpd/poiseuille.py
+++ b/tests/mdpd/poiseuille.py
@@ -10,7 +10,7 @@ vtarget = (1.0, 0, 0)
 
 density = 10
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(density)
@@ -28,7 +28,7 @@ den  = mir.Interactions.Pairwise('density', rd, kind="Density", density_kernel="
 mdpd = mir.Interactions.Pairwise('mdpd', rc, kind="MDPD", rd=rd, a=10.0, b=10.0, gamma=50.0, kBT=0.1, power=0.25)
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen = u.makeFrozenWallParticles(pvName="frozen", walls=[plate_lo, plate_hi], interactions=[den, mdpd], integrator=vv, number_density=density, nsteps=1000)
+frozen = u.makeFrozenWallParticles(pvName="frozen", walls=[plate_lo, plate_hi], interactions=[den, mdpd], integrator=vv, number_density=density, dt=dt, nsteps=1000)
 
 u.setWall(plate_lo, pv)
 u.setWall(plate_hi, pv)
@@ -63,7 +63,7 @@ vc_dump_every = 500
 
 u.registerPlugins(mir.Plugins.createVelocityControl("vc", "vcont", [pv], (0, 0, 0), domain, vc_sample_every, vc_tune_every, vc_dump_every, vtarget, Kp, Ki, Kd))
 
-u.run(20002)
+u.run(20002, dt=dt)
 
 # nTEST: mdpd.poiseuille
 # cd mdpd

--- a/tests/mdpd/rest.py
+++ b/tests/mdpd/rest.py
@@ -7,7 +7,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (16, 16, 16)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=3)
@@ -29,7 +29,7 @@ u.setIntegrator(vv, pv)
 
 u.registerPlugins(mir.Plugins.createStats('stats', "stats.csv", 1000))
 
-u.run(5001)
+u.run(5001, dt=dt)
 
 # nTEST: mdpd.rest
 # cd mdpd

--- a/tests/membrane/extra_force.py
+++ b/tests/membrane/extra_force.py
@@ -15,7 +15,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh = trimesh.load_mesh(args.mesh)
 
@@ -43,7 +43,7 @@ forces[id_max][0] = + force_magn
 u.registerPlugins(mir.Plugins.createMembraneExtraForce("extraRbcForce", pv_rbc, forces.tolist()))
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, 500, "ply/"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/membrane/juelicher.py
+++ b/tests/membrane/juelicher.py
@@ -16,7 +16,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 pv_rbc   = mir.ParticleVectors.MembraneVector("rbc", mass=1.0, mesh=mesh_rbc)
@@ -56,7 +56,7 @@ u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("meshdump",
                                                           ["areas", "mean_curvatures", "forces"],
                                                           "h5/rbc-"))
 
-u.run(2)
+u.run(2, dt=dt)
 
 # nTEST: membrane.bending.juelicher
 # cd membrane

--- a/tests/membrane/kantor.py
+++ b/tests/membrane/kantor.py
@@ -7,7 +7,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 pv_rbc   = mir.ParticleVectors.MembraneVector("rbc", mass=1.0, mesh=mesh_rbc)
@@ -45,7 +45,7 @@ u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("meshdump",
                                                           ["forces"],
                                                           "h5/rbc-"))
 
-u.run(2)
+u.run(2, dt=dt)
 
 # nTEST: membrane.bending.kantor
 # cd membrane

--- a/tests/membrane/lim.py
+++ b/tests/membrane/lim.py
@@ -18,7 +18,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("data/rbc.off", "data/sphere.off")
 pv_rbc   = mir.ParticleVectors.MembraneVector("rbc", mass=1.0, mesh=mesh_rbc)
@@ -58,7 +58,7 @@ u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("meshdump",
                                                           ["forces"],
                                                           "h5/rbc-"))
 
-u.run(2)
+u.run(2, dt=dt)
 
 # nTEST: membrane.shear.lim.ka.stressFree
 # cd membrane

--- a/tests/membrane/rest.filtered.py
+++ b/tests/membrane/rest.filtered.py
@@ -18,7 +18,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 
@@ -44,7 +44,7 @@ u.setInteraction(int_rbc, pv_rbc, pv_rbc)
 
 u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("mesh_dump", pv_rbc, 150, ["membrane_type_id"], "h5/mesh-"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/membrane/rest.juelicher.py
+++ b/tests/membrane/rest.juelicher.py
@@ -17,7 +17,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 
@@ -49,7 +49,7 @@ u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("meshdump",
                                                           ["areas", "mean_curvatures", "forces"],
                                                           "h5/rbc-"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/membrane/rest.lim.py
+++ b/tests/membrane/rest.lim.py
@@ -12,7 +12,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 
@@ -49,7 +49,7 @@ u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("meshdump",
                                                           ["forces"],
                                                           "h5/rbc-"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/membrane/rest.py
+++ b/tests/membrane/rest.py
@@ -18,7 +18,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 if args.sphere_stress_free:
     mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off", "sphere_mesh.off")
@@ -40,7 +40,7 @@ u.setInteraction(int_rbc, pv_rbc, pv_rbc)
 
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, 150, "ply/"))
 
-u.run(5000)
+u.run(5000, dt=dt)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/membrane/rest.substep.py
+++ b/tests/membrane/rest.substep.py
@@ -18,7 +18,7 @@ substeps = 1000
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt * substeps, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 pv_rbc   = mir.ParticleVectors.MembraneVector("rbc", mass=1.0, mesh=mesh_rbc)
@@ -36,7 +36,7 @@ u.setIntegrator(integrator, pv_rbc)
 
 u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_rbc, 1, "ply/"))
 
-u.run(50)
+u.run(50, dt=dt * substeps)
 
 if pv_rbc is not None:
     rbc_pos = pv_rbc.getCoordinates()

--- a/tests/membrane/wlc.py
+++ b/tests/membrane/wlc.py
@@ -12,7 +12,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh_rbc = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 pv_rbc   = mir.ParticleVectors.MembraneVector("rbc", mass=1.0, mesh=mesh_rbc)
@@ -50,7 +50,7 @@ u.registerPlugins(mir.Plugins.createDumpParticlesWithMesh("meshdump",
                                                           ["forces"],
                                                           "h5/rbc-"))
 
-u.run(2)
+u.run(2, dt=dt)
 
 # nTEST: membrane.shear.wlc
 # cd membrane

--- a/tests/mpi/rest.py
+++ b/tests/mpi/rest.py
@@ -9,7 +9,7 @@ def run(niter, statsFname, comm_address):
     ranks  = (2, 1, 1)
     domain = (12, 8, 10)
 
-    u = mir.Mirheo(ranks, domain, dt, debug_level=8, log_filename='log', comm_ptr=comm_address)
+    u = mir.Mirheo(ranks, domain, debug_level=8, log_filename='log', comm_ptr=comm_address)
 
     pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
     ic = mir.InitialConditions.Uniform(number_density=2)
@@ -25,7 +25,7 @@ def run(niter, statsFname, comm_address):
 
     u.registerPlugins(mir.Plugins.createStats('stats', statsFname, 1000))
 
-    u.run(niter)
+    u.run(niter, dt=dt)
 
 comm = MPI.COMM_WORLD
 run(2002, "stats1", MPI._addressof(comm))

--- a/tests/object_belonging/capsule.py
+++ b/tests/object_belonging/capsule.py
@@ -12,7 +12,7 @@ L = 3.0
 fact = 3
 domain = (fact*R, fact*R, fact*(L/2+R))
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 coords = [[-R, -R, -L/2-R],
           [ R,  R,  L/2+R]]
@@ -31,7 +31,7 @@ u.registerObjectBelongingChecker(inner_checker, pv_cap)
 
 pv_inner = u.applyObjectBelongingChecker(inner_checker, pv_outer, correct_every = 0, inside = "pv_inner")
 
-u.run(1)
+u.run(1, dt=0)
 
 if u.isMasterTask():
     pv_inner_pos = pv_inner.getCoordinates()

--- a/tests/object_belonging/cylinder.py
+++ b/tests/object_belonging/cylinder.py
@@ -12,7 +12,7 @@ L = 3.0
 fact = 3
 domain = (fact*R, fact*R, fact*L/2)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 coords = [[-R, -R, -L/2],
           [ R,  R,  L/2]]
@@ -31,7 +31,7 @@ u.registerObjectBelongingChecker(inner_checker, pv_cyl)
 
 pv_inner = u.applyObjectBelongingChecker(inner_checker, pv_outer, correct_every = 0, inside = "pv_inner")
 
-u.run(1)
+u.run(1, dt=0)
 
 if u.isMasterTask():
     pv_inner_pos = pv_inner.getCoordinates()

--- a/tests/object_belonging/ellipsoid.py
+++ b/tests/object_belonging/ellipsoid.py
@@ -10,7 +10,7 @@ axes = (1.0, 2.0, 3.0)
 fact = 3
 domain = (fact*axes[0], fact*axes[1], fact*axes[2])
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 coords = [[-axes[0], -axes[1], -axes[2]],
           [ axes[0],  axes[1],  axes[2]]]
@@ -29,7 +29,7 @@ u.registerObjectBelongingChecker(inner_checker, pv_ell)
 
 pv_inner = u.applyObjectBelongingChecker(inner_checker, pv_outer, correct_every = 0, inside = "pv_inner")
 
-u.run(1)
+u.run(1, dt=0)
 
 if u.isMasterTask():
     pv_inner_pos = pv_inner.getCoordinates()

--- a/tests/object_belonging/mesh.py
+++ b/tests/object_belonging/mesh.py
@@ -7,7 +7,7 @@ density = 4
 ranks  = (1, 1, 1)
 domain = (12, 8, 10)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 mesh = mir.ParticleVectors.MembraneMesh("rbc_mesh.off")
 
@@ -24,7 +24,7 @@ u.registerObjectBelongingChecker(inner_checker, pv_rbc)
 
 pv_inner = u.applyObjectBelongingChecker(inner_checker, pv_outer, correct_every = 0, inside = "pv_inner")
 
-u.run(1)
+u.run(1, dt=0)
 
 if u.isMasterTask():
     pv_inner_pos = pv_inner.getCoordinates()

--- a/tests/object_belonging/rod.py
+++ b/tests/object_belonging/rod.py
@@ -11,7 +11,7 @@ length = 5.0
 radius = 1.0
 domain = (8.0, 8.0, 2*length)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 def center_line(s): return (0., 0., (s-0.5) * length)
 def torsion(s): return 0.0
@@ -31,7 +31,7 @@ u.registerObjectBelongingChecker(inner_checker, pv_rod)
 
 pv_inner = u.applyObjectBelongingChecker(inner_checker, pv_outer, correct_every = 0, inside = "pv_inner")
 
-u.run(1)
+u.run(1, dt=0)
 
 if u.isMasterTask():
     pv_inner_pos = pv_inner.getCoordinates()

--- a/tests/plugins/anchor_particle.py
+++ b/tests/plugins/anchor_particle.py
@@ -6,7 +6,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = [8, 8, 8]
 
-u = mir.Mirheo(ranks, tuple(domain), dt=0.01, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 center = (domain[0]/2, domain[1]/2, domain[2]/2)
 
@@ -33,7 +33,7 @@ u.registerParticleVector(pv, ic)
 
 u.registerPlugins(mir.Plugins.createAnchorParticles("anchor", pv, positions, velocities, pids, 100, "anchor/"))
 
-u.run(500)
+u.run(500, dt=0.01)
 
 if pv:
     icpos = pv.getCoordinates()

--- a/tests/plugins/density_outlet.py
+++ b/tests/plugins/density_outlet.py
@@ -12,7 +12,7 @@ dt  = 0.001
 ranks  = (1, 1, 1)
 domain = (32, 32, 32)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 u.registerParticleVector(pv, mir.InitialConditions.Uniform(number_density=8))
@@ -35,7 +35,7 @@ bin_size = (1.0, 1.0, 1.0)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, [], 'h5/solvent-'))
 
-u.run(1010)
+u.run(1010, dt=dt)
 
 del (u)
 

--- a/tests/plugins/displacements.py
+++ b/tests/plugins/displacements.py
@@ -8,7 +8,7 @@ domain = (8, 8, 8)
 
 dt = 0.01
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 n = 20
 np.random.seed(42)
@@ -32,7 +32,7 @@ update_every = dump_every
 u.registerPlugins(mir.Plugins.createParticleDisplacement('disp', pv, update_every))
 u.registerPlugins(mir.Plugins.createDumpParticles('partDump', pv, dump_every, ["displacements"], 'h5/solvent_particles-'))
 
-u.run(100)
+u.run(100, dt=dt)
 
 # TEST: plugins.displacements
 # cd plugins

--- a/tests/plugins/impose_velocity.py
+++ b/tests/plugins/impose_velocity.py
@@ -8,7 +8,7 @@ axes = (1, 2, 3)
 ranks  = (1, 1, 1)
 domain = (8, 32, 24)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv1 = mir.ParticleVectors.ParticleVector('pv1', mass = 1)
 u.registerParticleVector(pv1, mir.InitialConditions.Uniform(number_density=4))
@@ -37,7 +37,7 @@ bin_size     = (1., 1., 1.)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv2], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(1010)
+u.run(1010, dt=dt)
 
 
 # nTEST: plugins.impose_velocity

--- a/tests/plugins/msd.py
+++ b/tests/plugins/msd.py
@@ -8,7 +8,7 @@ domain = (32, 32, 32)
 
 dt = 0.001
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density = 10)
@@ -29,7 +29,7 @@ u.registerPlugins(mir.Plugins.createMsd('msd', pv, t_eq, t_eq + t_measure, dump_
 
 t_tot = t_eq + t_measure
 
-u.run(int(t_tot / dt) + 1)
+u.run(int(t_tot / dt) + 1, dt=dt)
 
 # nTEST: plugins.msd
 # cd plugins

--- a/tests/plugins/particle_check.py
+++ b/tests/plugins/particle_check.py
@@ -7,7 +7,7 @@ domain = [4.0, 5.0, 6.0]
 
 dt = 100.0 # large dt to force the particles to go too far
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 
@@ -25,7 +25,7 @@ u.setIntegrator(vv, pv)
 check_every = 1
 u.registerPlugins(mir.Plugins.createParticleChecker('checker', check_every))
 
-u.run(2)
+u.run(2, dt=dt)
 
 
 # TEST: plugins.particle_check.bounds

--- a/tests/plugins/pin_objects.py
+++ b/tests/plugins/pin_objects.py
@@ -17,7 +17,7 @@ axes = (1, 2, 3)
 ranks  = (1, 1, 1)
 domain = (8, 16, 24)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[1, 2, 3,   1., 0, 0, 0],
          [5, 10, 15, 1,  1, 1, 1]]
@@ -52,7 +52,7 @@ dump_every=50
 u.registerPlugins( mir.Plugins.createPinObject('pin', pv_ell, dump_every, 'force/', velocity, omega) )
 u.registerPlugins( mir.Plugins.createDumpObjectStats("objStats", pv_ell, dump_every, "stats/") )
 
-u.run(2010)
+u.run(2010, dt=dt)
 
 
 # nTEST: plugins.pin_objects.1

--- a/tests/plugins/pvs_exchange.py
+++ b/tests/plugins/pvs_exchange.py
@@ -15,7 +15,7 @@ ranks  = args.ranks
 domain = (16, 16, 16)
 a = 1
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 def upHalf(r):
     return r[1] > domain[1] * args.fraction
@@ -48,7 +48,7 @@ u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv1], sample_every, du
                                                 ["velocities"], 'h5/solvent-'))
 u.registerPlugins(mir.Plugins.createExchangePVSFluxPlane("color_exchanger", pv1, pv2, (1., 0., 0., 0.)))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 del(u)
 

--- a/tests/plugins/rdf.py
+++ b/tests/plugins/rdf.py
@@ -10,7 +10,7 @@ domain = (16, 16, 16)
 rc = 1.0
 num_density = 8
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(num_density)
@@ -26,7 +26,7 @@ u.setIntegrator(vv, pv)
 
 u.registerPlugins(mir.Plugins.createRdf('rdf', pv, max_dist=2*rc, nbins=50, basename="rdf/pv-", every=5000))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 # nTEST: plugins.rdf
 # cd plugins

--- a/tests/plugins/relative_flow.py
+++ b/tests/plugins/relative_flow.py
@@ -9,7 +9,7 @@ axes = (1, 2, 3)
 ranks  = (1, 1, 1)
 domain = (8, 16, 24)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[domain[0]/2.0, domain[1]/2.0, domain[2]/2.0,  1., 0, 0, 0]]
 coords = np.loadtxt('sphere123.txt').tolist()
@@ -41,7 +41,7 @@ u.registerPlugins(mir.Plugins.createDumpAverageRelative(
     'field', [pv], pv_ell, 0,
     sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(5010)
+u.run(5010, dt=dt)
 
 
 # nTEST: plugins.relative_flow

--- a/tests/plugins/vacf.py
+++ b/tests/plugins/vacf.py
@@ -8,7 +8,7 @@ domain = (32, 32, 32)
 
 dt = 0.001
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density = 10)
@@ -29,7 +29,7 @@ u.registerPlugins(mir.Plugins.createVacf('vacf', pv, t_eq, t_eq + t_measure, dum
 
 t_tot = t_eq + t_measure
 
-u.run(int(t_tot / dt) + 1)
+u.run(int(t_tot / dt) + 1, dt=dt)
 
 # nTEST: plugins.vacf
 # cd plugins

--- a/tests/plugins/velocity_inlet.py
+++ b/tests/plugins/velocity_inlet.py
@@ -14,7 +14,7 @@ kBT = 0.0
 ranks  = (1, 1, 1)
 domain = (32, 32, 32)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 u.registerParticleVector(pv, mir.InitialConditions.Uniform(number_density=0))
@@ -85,7 +85,7 @@ dump_every = 1000
 bin_size = (1.0, 1.0, 1.0)
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, [], 'h5/solvent-'))
 
-u.run(1010)
+u.run(1010, dt=dt)
 
 del (u)
 

--- a/tests/python/unit_conversion.py
+++ b/tests/python/unit_conversion.py
@@ -30,8 +30,7 @@ mir.set_unit_registry(ureg, 'myL', 'myT', 'myM')
 
 # Test the unit conversion (not all arguments are probably dimensionalized below).
 domain = (10 * ureg.um, 15 * ureg.um, 20 * ureg.um)
-dt = 123 * ureg.us
-u = mir.Mirheo((1, 1, 1), domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo((1, 1, 1), domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass=1e-9 * ureg.kg)
 ic = mir.InitialConditions.Uniform(number_density=2 * ureg.um ** -3)
@@ -48,8 +47,9 @@ if u.isComputeTask():
     with open('snapshot/config.json') as f:
         config = json.loads(f.read())
 
-    print("domainGlobalSize =", config['MirState'][0]['domainGlobalSize'])
+    # `dt` should be equal to -1 at this point.
     print("dt =", config['MirState'][0]['dt'])
+    print("domainGlobalSize =", config['MirState'][0]['domainGlobalSize'])
     print("kBT =", config['Interaction'][0]['pairParams']['kBT'])
 
 # TEST: python.unit_conversion

--- a/tests/python/unit_conversion.py
+++ b/tests/python/unit_conversion.py
@@ -47,7 +47,7 @@ if u.isComputeTask():
     with open('snapshot/config.json') as f:
         config = json.loads(f.read())
 
-    # `dt` should be equal to -1 at this point.
+    # `dt` should be equal to MirState::InvalidDt (-1) at this point.
     print("dt =", config['MirState'][0]['dt'])
     print("domainGlobalSize =", config['MirState'][0]['domainGlobalSize'])
     print("kBT =", config['Interaction'][0]['pairParams']['kBT'])

--- a/tests/restart/belonging_checker.py
+++ b/tests/restart/belonging_checker.py
@@ -11,7 +11,7 @@ args = parser.parse_args()
 ranks  = (1, 1, 1)
 domain = (4, 6, 8)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3,
+u = mir.Mirheo(ranks, domain, debug_level=3,
               log_filename='log', no_splash=True,
               checkpoint_every = (0 if args.restart else 5))
     
@@ -29,7 +29,7 @@ inner = u.applyObjectBelongingChecker(checker, pv, inside='inner')
 
 if args.restart:
     u.restart("restart/")
-u.run(7)
+u.run(7, dt=0)
 
 if u.isComputeTask():
     ids = inner.get_indices()

--- a/tests/restart/bounce.py
+++ b/tests/restart/bounce.py
@@ -20,7 +20,7 @@ t_end = 2.5 + dt # time for one restart batch
 ranks  = args.ranks
 domain = (8, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log',
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log',
               checkpoint_every = int(0.5/dt), no_splash=True)
 
 nparts = 1000
@@ -70,7 +70,7 @@ if args.restart:
     u.restart("restart/")
 
 niters = int (t_end / dt)
-u.run(niters)
+u.run(niters, dt=dt)
 
 if args.restart and u.isComputeTask():
     pos = pv_rbc.getCoordinates()

--- a/tests/restart/bounce.rigid.py
+++ b/tests/restart/bounce.rigid.py
@@ -19,7 +19,7 @@ domain = [16., 8., 8.]
 dt   = 0.001
 t_end = 2.5 + dt # time for one restart batch
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log',
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log',
                checkpoint_every = int(0.5/dt), no_splash=True)
 
 nparts = 100
@@ -80,7 +80,7 @@ if args.restart:
     u.restart("restart/")
 
 niters = int (t_end / dt)
-u.run(niters)
+u.run(niters, dt=dt)
 
 # nTEST: restart.bounce.rigid.ellipsoid
 # set -eu

--- a/tests/restart/contact.ellipsoids.dp.py
+++ b/tests/restart/contact.ellipsoids.dp.py
@@ -21,7 +21,7 @@ domain = (16, 8, 8)
 
 nsteps = 5000
 
-u = mir.Mirheo(args.ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True,
+u = mir.Mirheo(args.ranks, domain, debug_level=3, log_filename='log', no_splash=True,
                checkpoint_every = (0 if args.restart else nsteps))
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
@@ -69,7 +69,7 @@ u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov=pv_ell, dump_
 if args.restart:
     u.restart("restart")
 
-u.run(nsteps)
+u.run(nsteps, dt=dt)
 
 # nTEST: restart.contact.rigid.ellipsoid
 # set -eu

--- a/tests/restart/interactions.py
+++ b/tests/restart/interactions.py
@@ -17,7 +17,7 @@ if args.restart:
 else:
     restart_folder="restart/"
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', checkpoint_every=5, checkpoint_folder=restart_folder, no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', checkpoint_every=5, checkpoint_folder=restart_folder, no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=2)
@@ -29,7 +29,7 @@ u.setInteraction(dpd, pv, pv)
 
 if args.restart:
     u.restart("restart/")
-u.run(7)
+u.run(7, dt=dt)
 
 
 # TEST: restart.interactions

--- a/tests/restart/object_vector.py
+++ b/tests/restart/object_vector.py
@@ -17,7 +17,7 @@ ranks  = args.ranks
 domain = (16, 16, 16)
 dt = 0
 
-u = mir.Mirheo(ranks, domain, dt, comm_ptr=MPI._addressof(comm),
+u = mir.Mirheo(ranks, domain, comm_ptr=MPI._addressof(comm),
               debug_level=3, log_filename='log', no_splash=True,
               checkpoint_every = (0 if args.restart else 5))
     
@@ -38,7 +38,7 @@ else:
 
 u.registerParticleVector(pv, ic)
 
-u.run(7)
+u.run(7, dt=dt)
 
 rank = comm.Get_rank()
 

--- a/tests/restart/particle_vector.py
+++ b/tests/restart/particle_vector.py
@@ -17,7 +17,7 @@ dt = 0
 
 comm = MPI.COMM_WORLD
 
-u = mir.Mirheo(ranks, domain, dt, comm_ptr = MPI._addressof(comm),
+u = mir.Mirheo(ranks, domain, comm_ptr = MPI._addressof(comm),
               debug_level=3, log_filename='log', no_splash=True,
               checkpoint_every = (0 if args.restart else 5))
 
@@ -30,7 +30,7 @@ else:
 
 u.registerParticleVector(pv, ic)
 
-u.run(7)
+u.run(7, dt=dt)
 
 rank = comm.Get_rank()
 

--- a/tests/restart/rigid_vector.py
+++ b/tests/restart/rigid_vector.py
@@ -14,7 +14,7 @@ ranks  = args.ranks
 domain = (16, 16, 16)
 dt = 0.0
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=9,
+u = mir.Mirheo(ranks, domain, debug_level=9,
               log_filename='log', no_splash=True,
               checkpoint_every = (0 if args.restart else 5))
 
@@ -48,7 +48,7 @@ u.setIntegrator(vv, pv)
 if args.restart:
     u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov=pv, dump_every=5, path="stats"))
 
-u.run(7)
+u.run(7, dt=dt)
 
 
 # TEST: restart.rigid_vector

--- a/tests/restart/walls.py
+++ b/tests/restart/walls.py
@@ -21,7 +21,7 @@ tend    = 5.0
 
 nsteps = int (tend / dt)
 
-u = mir.Mirheo(args.ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True,
+u = mir.Mirheo(args.ranks, domain, debug_level=3, log_filename='log', no_splash=True,
                checkpoint_every = (0 if args.restart else nsteps))
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
@@ -40,8 +40,8 @@ u.registerWall(plate_lo, nsteps_eq)
 u.registerWall(plate_hi, nsteps_eq)
 
 vv = mir.Integrators.VelocityVerlet("vv", )
-frozen_lo = u.makeFrozenWallParticles(pvName="plate_lo", walls=[plate_lo], interactions=[dpd], integrator=vv, number_density=density)
-frozen_hi = u.makeFrozenWallParticles(pvName="plate_hi", walls=[plate_hi], interactions=[dpd], integrator=vv, number_density=density)
+frozen_lo = u.makeFrozenWallParticles(pvName="plate_lo", walls=[plate_lo], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
+frozen_hi = u.makeFrozenWallParticles(pvName="plate_hi", walls=[plate_hi], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(plate_lo, pv)
 u.setWall(plate_hi, pv)
@@ -65,7 +65,7 @@ u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dum
 if args.restart:
     u.restart("restart")
 
-u.run(nsteps+1)
+u.run(nsteps + 1, dt=dt)
 
 # nTEST: restart.walls
 # cd restart

--- a/tests/rigids/create_capsule.py
+++ b/tests/rigids/create_capsule.py
@@ -13,7 +13,7 @@ def create_capsule(density, R, L, niter):
     fact = 3
     domain = (fact*R, fact*R, fact*(L/2+R))
     
-    u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
     
     dpd = mir.Interactions.Pairwise('dpd', rc=1.0, kind="DPD", a=10.0, gamma=10.0, kBT=0.5, power=0.5)
     vv = mir.Integrators.VelocityVerlet('vv')
@@ -26,7 +26,7 @@ def create_capsule(density, R, L, niter):
     fake_ic = mir.InitialConditions.Rigid(com_q, coords)
     belonging_checker = mir.BelongingCheckers.Capsule("checker")
     
-    pv_cap = u.makeFrozenRigidParticles(belonging_checker, fake_oV, fake_ic, [dpd], vv, density, 1.0, niter)
+    pv_cap = u.makeFrozenRigidParticles(belonging_checker, fake_oV, fake_ic, [dpd], vv, density, 1.0, dt=dt, nsteps=niter)
     
     if pv_cap:
         frozen_coords = pv_cap.getCoordinates()

--- a/tests/rigids/create_cylinder.py
+++ b/tests/rigids/create_cylinder.py
@@ -13,7 +13,7 @@ def create_cylinder(density, R, L, niter):
     fact = 3
     domain = (fact*R, fact*R, fact*L/2)
     
-    u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
     
     dpd = mir.Interactions.Pairwise('dpd', rc=1.0, kind="DPD", a=10.0, gamma=10.0, kBT=0.5, power=0.5)
     vv = mir.Integrators.VelocityVerlet('vv')
@@ -26,7 +26,7 @@ def create_cylinder(density, R, L, niter):
     fake_ic = mir.InitialConditions.Rigid(com_q, coords)
     belonging_checker = mir.BelongingCheckers.Cylinder("checker")
     
-    pv_cyl = u.makeFrozenRigidParticles(belonging_checker, fake_oV, fake_ic, [dpd], vv, density, 1.0, niter)
+    pv_cyl = u.makeFrozenRigidParticles(belonging_checker, fake_oV, fake_ic, [dpd], vv, density, 1.0, dt=dt, nsteps=niter)
     
     if pv_cyl:
         frozen_coords = pv_cyl.getCoordinates()

--- a/tests/rigids/create_ellipsoid.py
+++ b/tests/rigids/create_ellipsoid.py
@@ -14,7 +14,7 @@ def create_ellipsoid(density, axes, niter):
     fact = 3
     domain = (fact*axes[0], fact*axes[1], fact*axes[2])
     
-    u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
     
     dpd = mir.Interactions.Pairwise('dpd', rc=1.0, kind="DPD", a=10.0, gamma=10.0, kBT=0.5, power=0.5)
     vv = mir.Integrators.VelocityVerlet('vv')
@@ -27,7 +27,7 @@ def create_ellipsoid(density, axes, niter):
     fake_ic = mir.InitialConditions.Rigid(com_q=com_q, coords=coords)
     belonging_checker = mir.BelongingCheckers.Ellipsoid("ellipsoidChecker")
     
-    pv_ell = u.makeFrozenRigidParticles(belonging_checker, fake_oV, fake_ic, [dpd], vv, density, 1.0, niter)
+    pv_ell = u.makeFrozenRigidParticles(belonging_checker, fake_oV, fake_ic, [dpd], vv, density, 1.0, dt=dt, nsteps=niter)
     
     if pv_ell:
         frozen_coords = pv_ell.getCoordinates()

--- a/tests/rigids/create_from_mesh.py
+++ b/tests/rigids/create_from_mesh.py
@@ -25,7 +25,7 @@ def create_from_mesh(density, vertices, triangles, inertia, niter):
 
     ranks  = (1, 1, 1)
     
-    u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
     
     dpd = mir.Interactions.Pairwise('dpd', rc=1.0, kind="DPD", a=10.0, gamma=10.0, kBT=0.5, power=0.5)
     vv = mir.Integrators.VelocityVerlet('vv')
@@ -39,7 +39,7 @@ def create_from_mesh(density, vertices, triangles, inertia, niter):
     fake_ic = mir.InitialConditions.Rigid(com_q=com_q, coords=coords)
     belonging_checker = mir.BelongingCheckers.Mesh("meshChecker")
     
-    pvMesh = u.makeFrozenRigidParticles(belonging_checker, fake_ov, fake_ic, [dpd], vv, density, 1.0, niter)
+    pvMesh = u.makeFrozenRigidParticles(belonging_checker, fake_ov, fake_ic, [dpd], vv, density, 1.0, dt=dt, nsteps=niter)
 
     if pvMesh:
         frozen_coords = pvMesh.getCoordinates()

--- a/tests/rigids/force_torque.py
+++ b/tests/rigids/force_torque.py
@@ -19,7 +19,7 @@ axes = tuple(args.axes)
 ranks  = (1, 1, 1)
 domain = (16, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[0.5 * domain[0], 0.5 * domain[1], 0.5 * domain[2],   1., 0, 0, 0]]
 coords = np.loadtxt(args.coords).tolist()
@@ -52,7 +52,7 @@ if args.const_torque:
 if args.withMesh:
     u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_ell, 1000, path="ply/"))
 
-u.run(10000)
+u.run(10000, dt=dt)
 
 
 # nTEST: rigids.const_force

--- a/tests/rigids/magnetic_orientation.py
+++ b/tests/rigids/magnetic_orientation.py
@@ -19,7 +19,7 @@ axes = tuple(args.axes)
 ranks  = (1, 1, 1)
 domain = (16, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[0.5 * domain[0], 0.5 * domain[1], 0.5 * domain[2],   1., 0, 0, 0]]
 coords = np.loadtxt(args.coords).tolist()
@@ -56,7 +56,7 @@ u.registerPlugins(mir.Plugins.createMagneticOrientation("externalB", pv_ell, mom
 if args.withMesh:
     u.registerPlugins(mir.Plugins.createDumpMesh("mesh_dump", pv_ell, 1000, path="ply/"))
 
-u.run(10000)
+u.run(10000, dt=dt)
 
 del(u)
 

--- a/tests/rigids/many_random_flying.py
+++ b/tests/rigids/many_random_flying.py
@@ -17,7 +17,7 @@ axes = (1, 2, 3)
 ranks  = tuple(args.nranks)
 domain = (31, 18, 59)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 np.random.seed(84)
 com_q = np.random.rand(args.nobjects, 7)
@@ -35,7 +35,7 @@ u.registerIntegrator(vv_ell)
 u.setIntegrator(vv_ell, pv_ell)
 
 u.registerPlugins( mir.Plugins.createDumpObjectStats("objStats", pv_ell, dump_every=10, path="stats") )
-u.run(1000)
+u.run(1000, dt=dt)
 
 
 # nTEST: rigids.many_random_flying.onerank

--- a/tests/rod/forces.py
+++ b/tests/rod/forces.py
@@ -19,7 +19,7 @@ domain = [16, 16, 16]
 
 dt = 1e-3
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=8, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=8, log_filename='log', no_splash=True)
 
 com_q = [[ 8., 8., 8.,    1.0, 0.0, 0.0, 0.0]]
 
@@ -84,7 +84,7 @@ dump_every = 1
 u.registerPlugins(mir.Plugins.createForceSaver("forceSaver", rv))
 u.registerPlugins(mir.Plugins.createDumpParticles('rod_dump', rv, dump_every, ["forces"], 'h5/rod-'))
 
-u.run(2)
+u.run(2, dt=dt)
 
 del u
 

--- a/tests/rod/polymorphic_states.py
+++ b/tests/rod/polymorphic_states.py
@@ -17,7 +17,7 @@ t_dump_every = 1.0
 L = 5.0
 num_segments = 60
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[ 8., 8., 8.,    1.0, 0.0, 0.0, 0.0]]
 
@@ -74,7 +74,7 @@ u.registerPlugins(mir.Plugins.createParticleDrag('rod_drag', rv, drag))
 dump_every = int (t_dump_every/dt)
 u.registerPlugins(mir.Plugins.createDumpParticles('rod_dump', rv, dump_every, ["states"], 'h5/rod_particles-'))
 
-u.run(int (t_end / dt))
+u.run(int(t_end / dt), dt=dt)
 
 if rv is not None:
     pos = rv.getCoordinates()

--- a/tests/rod/rest.py
+++ b/tests/rod/rest.py
@@ -22,7 +22,7 @@ L = 50.0
 num_segments = 200
 sub_steps = args.sub_steps
 
-u = mir.Mirheo(ranks, tuple(domain), dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, tuple(domain), debug_level=3, log_filename='log', no_splash=True)
 
 com_q = [[ 8., 8., 8.,    1.0, 0.0, 0.0, 0.0]]
 
@@ -75,7 +75,7 @@ if args.drag > 0.0:
 dump_every = int (t_dump_every/dt)
 u.registerPlugins(mir.Plugins.createDumpParticles('rod_dump', rv, dump_every, [], 'h5/rod_particles-'))
 
-u.run(int (t_end / dt))
+u.run(int(t_end / dt), dt=dt)
 
 if rv is not None:
     pos = rv.getCoordinates()

--- a/tests/sdpd/double_poiseuille.py
+++ b/tests/sdpd/double_poiseuille.py
@@ -9,7 +9,7 @@ domain = (16, 16, 16)
 ext_force = 1.0
 rc = 1.0
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1.0)
 ic = mir.InitialConditions.Uniform(number_density=10)
@@ -34,7 +34,7 @@ u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dum
                                                 ["velocities"],
                                                 'h5/solvent-'))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 # nTEST: sdpd.double_poiseuille
 # cd sdpd

--- a/tests/sdpd/rest.py
+++ b/tests/sdpd/rest.py
@@ -14,7 +14,7 @@ dt = 0.001
 ranks  = (1, 1, 1)
 domain = (16, 16, 16)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log')
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log')
 
 pv = mir.ParticleVectors.ParticleVector('pv', args.mass)
 ic = mir.InitialConditions.Uniform(number_density=10)
@@ -50,7 +50,7 @@ u.setIntegrator(vv, pv)
 
 u.registerPlugins(mir.Plugins.createStats('stats', "stats", 1000))
 
-u.run(5001)
+u.run(5001, dt=dt)
 
 # nTEST: sdpd.rest
 # cd sdpd

--- a/tests/sdpd/rigid.py
+++ b/tests/sdpd/rigid.py
@@ -21,7 +21,7 @@ density  = args.density
 ranks  = (1, 1, 1)
 domain = (16, 8, 8)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_sol = mir.ParticleVectors.ParticleVector('solvent', mass = 1)
 ic_sol = mir.InitialConditions.Uniform(density)
@@ -78,7 +78,7 @@ u.registerPlugins(mir.Plugins.createDumpParticles('partDump_sol', pv_sol, dump_e
 
 u.registerPlugins(mir.Plugins.createDumpObjectStats("objStats", ov=pv_ell, dump_every=dump_every, path="stats"))
 
-u.run(10000)
+u.run(10000, dt=dt)
 
 
 # nTEST: sdpd.fsi.ellipsoid

--- a/tests/snapshot/interactions.py
+++ b/tests/snapshot/interactions.py
@@ -15,9 +15,8 @@ parser.add_argument('--load-from', type=str)
 args = parser.parse_args()
 
 if not args.load_from:
-    # Keep dt as 0.1, just to see the difference between float and double.
-    u = mir.Mirheo(args.ranks, domain=(4, 6, 8), dt=0.1,
-                   debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(args.ranks, domain=(4, 6, 8),
+                   debug_level=15, log_filename='log', no_splash=True)
 
     pv = mir.ParticleVectors.ParticleVector('pv', mass=1)
     ic = mir.InitialConditions.Uniform(number_density=2)
@@ -37,7 +36,7 @@ if not args.load_from:
 else:
     u = mir.Mirheo(args.ranks, snapshot=args.load_from, debug_level=3, log_filename='log', no_splash=True)
     u.saveSnapshot(args.save_to)
-    u.run(1)  # Test that it does not crash.
+    u.run(0, dt=0.1)  # Test that it does not crash.
 
 # NOTE: The development docs include this test case as a JSON sample.
 #       If updating this test case, check if the docs has to be updated.

--- a/tests/snapshot/membrane_vectors.py
+++ b/tests/snapshot/membrane_vectors.py
@@ -16,10 +16,9 @@ parser.add_argument('--load-from', type=str)
 args = parser.parse_args()
 
 domain = (4, 6, 8)
-dt = 0.1
 
 if not args.load_from:
-    u = mir.Mirheo(args.ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(args.ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
     mesh1 = mir.ParticleVectors.MembraneMesh('mesh_dummy1.off')
     mesh2 = mir.ParticleVectors.MembraneMesh('mesh_dummy2.off')
@@ -32,7 +31,7 @@ if not args.load_from:
 else:
     u = mir.Mirheo(args.ranks, snapshot=args.load_from, debug_level=3, log_filename='log', no_splash=True)
     u.saveSnapshot(args.save_to)
-    u.run(1)  # Test that it does not crash.
+    u.run(1, dt=0.1)  # Test that it does not crash.
 
 # TODO: Add h5diff once particles (membranes) are added. h5diff does not work
 # for empty data sets for some reason.

--- a/tests/snapshot/periodic.py
+++ b/tests/snapshot/periodic.py
@@ -7,7 +7,7 @@ We test that there are that many folders and that the currentStep changes.
 
 import mirheo as mir
 
-u = mir.Mirheo(nranks=(1, 1, 1), domain=(4, 6, 8), dt=0.125, debug_level=3,
+u = mir.Mirheo(nranks=(1, 1, 1), domain=(4, 6, 8), debug_level=3,
                log_filename='log', no_splash=True,
                checkpoint_every=10, checkpoint_mode='Incremental',
                checkpoint_folder='periodic_snapshots/snapshot_', checkpoint_mechanism='Snapshot')
@@ -25,7 +25,7 @@ u.setInteraction(dpd, pv, pv)
 
 minimize = mir.Integrators.Minimize('minimize', max_displacement=1. / 1024)
 u.registerIntegrator(minimize)
-u.run(45)
+u.run(45, dt=0.125)
 
 # TEST: snapshot.periodic
 # cd snapshot

--- a/tests/snapshot/plugins.py
+++ b/tests/snapshot/plugins.py
@@ -10,7 +10,7 @@ parser.add_argument('--load-from', type=str)
 args = parser.parse_args()
 
 if not args.load_from:
-    u = mir.Mirheo(args.ranks, domain=(4, 6, 8), dt=0.1, debug_level=3, log_filename='log', no_splash=True)
+    u = mir.Mirheo(args.ranks, domain=(4, 6, 8), debug_level=3, log_filename='log', no_splash=True)
 
     mesh = mir.ParticleVectors.MembraneMesh('mesh_dummy1.off')
     ov = mir.ParticleVectors.MembraneVector('ov', mesh=mesh, mass=1)

--- a/tests/stress/double_poiseuille.py
+++ b/tests/stress/double_poiseuille.py
@@ -12,7 +12,7 @@ sample_every = 2
 dump_every   = 1000
 bin_size     = (1., 1., 1.)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=4)
@@ -29,7 +29,7 @@ u.setIntegrator(vv, pv)
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size,
                                                 ["velocities", "stresses"], 'h5/solvent-'))
 
-u.run(5002)
+u.run(5002, dt=dt)
 
 # nTEST: stress.double_poiseuille
 # cd stress

--- a/tests/stress/pressure.py
+++ b/tests/stress/pressure.py
@@ -17,7 +17,7 @@ domain = (32, 32, 32)
 tdump_every = 0.001
 dump_every = int(tdump_every / dt)
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv_name="pv"
 path="pressure"
@@ -41,7 +41,7 @@ h = (1.0, 1.0, 1.0)
 
 u.registerPlugins(mir.Plugins.createVirialPressurePlugin('Pressure', pv, predicate_all_domain, h, dump_every, path))
 
-u.run(2001)
+u.run(2001, dt=dt)
 
 volume = domain[0]*domain[1]*domain[2]
 

--- a/tests/test_data/snapshot.ref.snapshot.interactions.txt
+++ b/tests/test_data/snapshot.ref.snapshot.interactions.txt
@@ -101,7 +101,7 @@
                 6,
                 8
             ],
-            "dt": 0.10000000149011612,
+            "dt": -1,
             "currentTime": 0,
             "currentStep": 0,
             "units": {

--- a/tests/test_data/snapshot.ref.snapshot.membrane_vectors.txt
+++ b/tests/test_data/snapshot.ref.snapshot.membrane_vectors.txt
@@ -78,7 +78,7 @@
                 6,
                 8
             ],
-            "dt": 0.10000000149011612,
+            "dt": -1,
             "currentTime": 0,
             "currentStep": 0,
             "units": {

--- a/tests/test_data/snapshot.ref.snapshot.plugins.txt
+++ b/tests/test_data/snapshot.ref.snapshot.plugins.txt
@@ -171,7 +171,7 @@
                 6,
                 8
             ],
-            "dt": 0.10000000149011612,
+            "dt": -1,
             "currentTime": 0,
             "currentStep": 0,
             "units": {

--- a/tests/test_data/unit_conversion.ref.python.unit_conversion.txt
+++ b/tests/test_data/unit_conversion.ref.python.unit_conversion.txt
@@ -1,3 +1,3 @@
+dt = -1
 domainGlobalSize = [20, 30, 40]
-dt = 492
 kBT = 2.25

--- a/tests/test_data_double/snapshot.ref.snapshot.interactions.txt
+++ b/tests/test_data_double/snapshot.ref.snapshot.interactions.txt
@@ -101,7 +101,7 @@
                 6,
                 8
             ],
-            "dt": 0.10000000000000001,
+            "dt": -1,
             "currentTime": 0,
             "currentStep": 0,
             "units": {

--- a/tests/test_data_double/snapshot.ref.snapshot.membrane_vectors.txt
+++ b/tests/test_data_double/snapshot.ref.snapshot.membrane_vectors.txt
@@ -78,7 +78,7 @@
                 6,
                 8
             ],
-            "dt": 0.10000000000000001,
+            "dt": -1,
             "currentTime": 0,
             "currentStep": 0,
             "units": {

--- a/tests/test_data_double/snapshot.ref.snapshot.plugins.txt
+++ b/tests/test_data_double/snapshot.ref.snapshot.plugins.txt
@@ -171,7 +171,7 @@
                 6,
                 8
             ],
-            "dt": 0.10000000000000001,
+            "dt": -1,
             "currentTime": 0,
             "currentStep": 0,
             "units": {

--- a/tests/test_data_double/unit_conversion.ref.python.unit_conversion.txt
+++ b/tests/test_data_double/unit_conversion.ref.python.unit_conversion.txt
@@ -1,3 +1,3 @@
+dt = -1
 domainGlobalSize = [20, 30, 40]
-dt = 492
 kBT = 2.25

--- a/tests/walls/analytic/channel.py
+++ b/tests/walls/analytic/channel.py
@@ -17,7 +17,7 @@ force = (1.0, 0, 0)
 density = 4
 rc = 1.0
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -38,7 +38,7 @@ elif args.type == "squarePipe":
 u.registerWall(wall, 0)
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen_wall = u.makeFrozenWallParticles(pvName="wall", walls=[wall], interactions=[dpd], integrator=vv, number_density=density)
+frozen_wall = u.makeFrozenWallParticles(pvName="wall", walls=[wall], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(wall, pv)
 
@@ -62,7 +62,7 @@ bin_size     = (1., 1., 1.0)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(7002)
+u.run(7002, dt=dt)
 
 # nTEST: walls.analytic.channel.cylinder
 # cd walls/analytic

--- a/tests/walls/analytic/couette.py
+++ b/tests/walls/analytic/couette.py
@@ -19,7 +19,7 @@ gdot    = 0.5 # shear rate
 T       = 3.0 # period for oscillating plate case
 tend    = 10.1
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -40,8 +40,8 @@ u.registerWall(plate_lo, 1000)
 u.registerWall(plate_hi, 1000)
 
 vv = mir.Integrators.VelocityVerlet("vv", )
-frozen_lo = u.makeFrozenWallParticles(pvName="plate_lo", walls=[plate_lo], interactions=[dpd], integrator=vv, number_density=density)
-frozen_hi = u.makeFrozenWallParticles(pvName="plate_hi", walls=[plate_hi], interactions=[dpd], integrator=vv, number_density=density)
+frozen_lo = u.makeFrozenWallParticles(pvName="plate_lo", walls=[plate_lo], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
+frozen_hi = u.makeFrozenWallParticles(pvName="plate_hi", walls=[plate_hi], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(plate_lo, pv)
 u.setWall(plate_hi, pv)
@@ -65,7 +65,7 @@ bin_size     = (8., 8., 1.0)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run((int)(tend/dt))
+u.run(int(tend / dt), dt=dt)
 
 # nTEST: walls.analytic.couette
 # cd walls/analytic

--- a/tests/walls/analytic/obstacle.py
+++ b/tests/walls/analytic/obstacle.py
@@ -16,7 +16,7 @@ force = (1.0, 0, 0)
 
 density = 4
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -36,7 +36,7 @@ elif args.type == "sphere":
 u.registerWall(wall, 0)
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen_wall = u.makeFrozenWallParticles(pvName="wall", walls=[wall], interactions=[dpd], integrator=vv, number_density=density)
+frozen_wall = u.makeFrozenWallParticles(pvName="wall", walls=[wall], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(wall, pv)
 
@@ -60,7 +60,7 @@ bin_size     = (1., 1., 1.0)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(7002)
+u.run(7002, dt=dt)
 
 # nTEST: walls.analytic.obstacle.cylinder
 # cd walls/analytic

--- a/tests/walls/analytic/plates.py
+++ b/tests/walls/analytic/plates.py
@@ -10,7 +10,7 @@ force = (1.0, 0, 0)
 
 density = 4
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -25,7 +25,7 @@ u.registerWall(plate_lo, 0)
 u.registerWall(plate_hi, 0)
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen = u.makeFrozenWallParticles(pvName="plates", walls=[plate_lo, plate_hi], interactions=[dpd], integrator=vv, number_density=density)
+frozen = u.makeFrozenWallParticles(pvName="plates", walls=[plate_lo, plate_hi], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(plate_lo, pv)
 u.setWall(plate_hi, pv)
@@ -45,7 +45,7 @@ bin_size     = (1., 1., 0.5)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(7002)
+u.run(7002, dt=dt)
 
 # nTEST: walls.analytic.plates
 # cd walls/analytic

--- a/tests/walls/analytic/taylor_couette.py
+++ b/tests/walls/analytic/taylor_couette.py
@@ -13,7 +13,7 @@ rc      = 1.0
 omega   = 0.5 # angular velocity of outer cylinder; inner is fixed
 tend    = 10.1
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -30,8 +30,8 @@ u.registerWall(cylinder_in,  1000)
 u.registerWall(cylinder_out, 1000)
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen_in  = u.makeFrozenWallParticles(pvName="cyl_in",  walls=[cylinder_in],  interactions=[dpd], integrator=vv, number_density=density)
-frozen_out = u.makeFrozenWallParticles(pvName="cyl_out", walls=[cylinder_out], interactions=[dpd], integrator=vv, number_density=density)
+frozen_in  = u.makeFrozenWallParticles(pvName="cyl_in",  walls=[cylinder_in],  interactions=[dpd], integrator=vv, number_density=density, dt=dt)
+frozen_out = u.makeFrozenWallParticles(pvName="cyl_out", walls=[cylinder_out], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(cylinder_in,  pv)
 u.setWall(cylinder_out, pv)
@@ -52,7 +52,7 @@ bin_size     = (1., 1., 1.)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run((int)(tend/dt))
+u.run(int(tend / dt), dt=dt)
 
 # nTEST: walls.analytic.taylor_couette
 # cd walls/analytic

--- a/tests/walls/force_collector.py
+++ b/tests/walls/force_collector.py
@@ -16,7 +16,7 @@ tend    = 10.1
 
 gdpd = 11.0
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1.0)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -33,8 +33,8 @@ u.registerWall(plate_lo, 1000)
 u.registerWall(plate_hi, 1000)
 
 vv = mir.Integrators.VelocityVerlet("vv", )
-frozen_lo = u.makeFrozenWallParticles(pvName="plate_lo", walls=[plate_lo], interactions=[dpd], integrator=vv, number_density=density)
-frozen_hi = u.makeFrozenWallParticles(pvName="plate_hi", walls=[plate_hi], interactions=[dpd], integrator=vv, number_density=density)
+frozen_lo = u.makeFrozenWallParticles(pvName="plate_lo", walls=[plate_lo], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
+frozen_hi = u.makeFrozenWallParticles(pvName="plate_hi", walls=[plate_hi], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(plate_lo, pv)
 u.setWall(plate_hi, pv)
@@ -56,7 +56,7 @@ outname_lo = 'wallForceLo.txt'
 u.registerPlugins(mir.Plugins.createWallForceCollector('forceCollectorHi', plate_hi, frozen_hi, sample_every, dump_every, outname_hi))
 u.registerPlugins(mir.Plugins.createWallForceCollector('forceCollectorLo', plate_lo, frozen_lo, sample_every, dump_every, outname_lo))
 
-u.run((int)(tend/dt))
+u.run(int(tend / dt), dt=dt)
 
 if u.isComputeTask():
     A = domain[0] * domain[1]

--- a/tests/walls/sdf/from_file.py
+++ b/tests/walls/sdf/from_file.py
@@ -18,7 +18,7 @@ domain = args.domain
 
 density = 8
 
-u = mir.Mirheo(ranks, domain, dt, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 pv = mir.ParticleVectors.ParticleVector('pv', mass = 1)
 ic = mir.InitialConditions.Uniform(number_density=density)
@@ -33,7 +33,7 @@ u.dumpWalls2XDMF([wall], (0.5, 0.5, 0.5), filename='h5/wall')
 
 
 vv = mir.Integrators.VelocityVerlet("vv")
-frozen_wall = u.makeFrozenWallParticles(pvName="sdf", walls=[wall], interactions=[dpd], integrator=vv, number_density=density)
+frozen_wall = u.makeFrozenWallParticles(pvName="sdf", walls=[wall], interactions=[dpd], integrator=vv, number_density=density, dt=dt)
 
 u.setWall(wall, pv)
 
@@ -57,7 +57,7 @@ bin_size     = (1., 1., 1.0)
 
 u.registerPlugins(mir.Plugins.createDumpAverage('field', [pv], sample_every, dump_every, bin_size, ["velocities"], 'h5/solvent-'))
 
-u.run(args.niters)
+u.run(args.niters, dt=dt)
 
 # nTEST: walls.sdf.from_file.profile
 # cd walls/sdf

--- a/tests/walls/volume/cylinder.py
+++ b/tests/walls/volume/cylinder.py
@@ -6,7 +6,7 @@ import mirheo as mir
 ranks  = (1, 1, 1)
 domain = (16, 16, 8)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 center=(domain[0]*0.5, domain[1]*0.5)
 wall = mir.Walls.Cylinder("cylinder", center=center, radius=domain[1]*0.4, axis="z", inside=True)

--- a/tests/walls/volume/plates.py
+++ b/tests/walls/volume/plates.py
@@ -11,7 +11,7 @@ args = parser.parse_args()
 ranks  = (1, 1, 1)
 domain = (8, 16, 8)
 
-u = mir.Mirheo(ranks, domain, dt=0, debug_level=3, log_filename='log', no_splash=True)
+u = mir.Mirheo(ranks, domain, debug_level=3, log_filename='log', no_splash=True)
 
 plate_lo = mir.Walls.Plane("plate_lo", normal=(0, 0, -1), pointThrough=(0, 0,              args.D))
 plate_hi = mir.Walls.Plane("plate_hi", normal=(0, 0,  1), pointThrough=(0, 0,  domain[2] - args.D))

--- a/units/integration/particles/main.cpp
+++ b/units/integration/particles/main.cpp
@@ -13,7 +13,7 @@ static void run_gpu(Integrator *integrator, ParticleVector *pv, int nsteps, MirS
 
     for (int i = 0; i < nsteps; ++i) {
         state->currentStep = i;
-        state->currentTime = i * state->dt;
+        state->currentTime = i * state->getDt();
 
         integrator->execute(pv, defaultStream);
     }

--- a/units/integration/rigid/main.cpp
+++ b/units/integration/rigid/main.cpp
@@ -97,7 +97,7 @@ static inline RigidMotion advanceGPU(const Params& p)
 
     gpuIntegrator.setPrerequisites(rov.get());
 
-    for (; state.currentTime < p.tend; state.currentTime += state.dt)
+    for (; state.currentTime < p.tend; state.currentTime += state.getDt())
     {
         gpuIntegrator.execute(rov.get(), defaultStream);
     }

--- a/units/rng/main.cpp
+++ b/units/rng/main.cpp
@@ -21,7 +21,7 @@ static std::vector<real> generateSamples(Gen gen, real dt, long n)
     for (state.currentStep = 0; state.currentStep < n; ++state.currentStep)
     {
         samples[state.currentStep] = gen.generate(&state);
-        state.currentTime += state.dt;
+        state.currentTime += state.getDt();
     }
 
     return samples;

--- a/units/snapshot/main.cpp
+++ b/units/snapshot/main.cpp
@@ -187,7 +187,7 @@ TEST(Snapshot, DumpUndumpInteractions)
     SaverContext context;
     Saver saver{&context};
 
-    Mirheo mirheo{MPI_COMM_WORLD, {1, 1, 1}, {10.0_r, 10.0_r, 10.0_r}, 0.1_r, {"log", 3, true}, {}, false};
+    Mirheo mirheo{MPI_COMM_WORLD, {1, 1, 1}, {10.0_r, 10.0_r, 10.0_r}, {"log", 3, true}, {}, false};
     auto pairwise = interaction_factory::createPairwiseInteraction(
             mirheo.getState(), "interaction", 1.0, "DPD",
             {{"a", 10.0_r}, {"gamma", 10.0_r}, {"kBT", 1.0_r}, {"power", 0.5_r}});


### PR DESCRIPTION
This is a preparation for multistages simulations with various dt and
for adaptive time steps.

The public MirState::dt was replaced with getter MirState::getDt()
and setter setDt(...). The getter is accessible only during Mirheo::run().
If invoked outside of it, it throws an exception.