### PR TITLE
[Minor Bug]: Do not call MPI_Init when MPI is already initialized

### DIFF
--- a/src/mirheo/core/mirheo.cpp
+++ b/src/mirheo/core/mirheo.cpp
@@ -168,9 +168,14 @@ Mirheo::Mirheo(int3 nranks3D, real3 globalDomainSize,
                LogInfo logInfo, CheckpointInfo checkpointInfo,
                real maxObjHalfLength, bool gpuAwareMPI)
 {
-    MPI_Init(nullptr, nullptr);
+    int alreadyInitialized = 0;
+    MPI_Initialized(&alreadyInitialized);
+    if (!alreadyInitialized) {
+        // e.g. mpi4py imported from python initializes MPI before us
+        MPI_Init(nullptr, nullptr);
+        initializedMpi_ = true;
+    }
     MPI_Comm_dup(MPI_COMM_WORLD, &comm_);
-    initializedMpi_ = true;
 
     initLogger(comm_, logInfo);
     init(nranks3D, globalDomainSize, logInfo,


### PR DESCRIPTION
The no-communicator constructor called MPI_Init unconditionally. When the driving python script imports mpi4py before creating the coordinator (as several tests do), MPI is already initialized and the second MPI_Init is erroneous: Open MPI 5 prints an error banner into the captured output, which makes md.multistage and md.minimization fail and can corrupt the stdout of other tests. Guard the call with MPI_Initialized and only take ownership of MPI_Finalize when we actually initialized MPI ourselves.