### PR TITLE
docs,cmake: document the actual C++17 / CUDA 11 build requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,16 @@ message("Compiling libmirheo version ${MIR_VERSION_CMAKE_FORMAT}")
 
 project(Mirheo VERSION ${MIR_VERSION_CMAKE_FORMAT} LANGUAGES C CXX CUDA)
 
+# Mirheo is compiled as C++17 (see src/mirheo/core/CMakeLists.txt, which sets
+# cxx_std_17 and passes --std=c++17 to nvcc). nvcc only accepts --std=c++17 from
+# CUDA 11.0 onwards, so older toolkits fail late with the unhelpful message
+# "nvcc fatal : Value 'c++17' is not defined for option 'std'". Fail early instead.
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.0)
+  message(FATAL_ERROR
+      "Mirheo requires the CUDA toolkit >= 11.0 for C++17 support in nvcc, "
+      "but version ${CMAKE_CUDA_COMPILER_VERSION} was found.")
+endif()
+
 # ***********************
 # Alias directories
 # ***********************

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -12,9 +12,9 @@ Mirheo
 Mirheo requires at least Kepler-generation NVIDIA GPU and depends on a few external tools and libraries:
 
 - Unix-based OS
-- NVIDIA CUDA toolkit version >= 9.2
-- gcc compiler with c++14 support compatible with CUDA installation
-- CMake version >= 3.8
+- NVIDIA CUDA toolkit version >= 11.0
+- gcc compiler with c++17 support compatible with CUDA installation
+- CMake version >= 3.10
 - Python interpreter version >= 3.4
 - MPI library
 - HDF5 parallel library


### PR DESCRIPTION
### Summary

`docs/source/user/installation.rst` lists the requirements as CUDA >= 9.2 and "gcc compiler with c++14 support", but libmirheo has been compiled as C++17 since the C++17 migration: `src/mirheo/core/CMakeLists.txt` sets `cxx_std_17` and passes `--std=c++17` to nvcc. nvcc only accepts `--std=c++17` from CUDA 11.0 onwards, so anyone following the documented minimum hits the failure reported in #154: `nvcc fatal : Value 'c++17' is not defined for option 'std'`.

### Changes

In `installation.rst`, the documented requirements become CUDA >= 11.0 and c++17. The documented CMake minimum also moves 3.8 -> 3.10, which is what `cmake_minimum_required()` in `CMakeLists.txt` has actually required.

In `CMakeLists.txt`, `CMAKE_CUDA_COMPILER_VERSION` is checked immediately after `project()`, so an unsupported toolkit fails at configure time with a message naming the cause, rather than as a bare nvcc error part-way through the build.

### Testing

Tested on Google Colab (Tesla T4): CUDA 12.8.93, gcc 11.4.0, CMake 3.31.10, OpenMPI 3.1, parallel HDF5 1.10.7 via `libhdf5-openmpi-dev`.

Confirmed `CMAKE_CUDA_COMPILER_VERSION` resolves to `12.8.93` immediately after `project(... LANGUAGES C CXX CUDA)`, so the guard evaluates correctly and does not fire on a supported toolchain. A full configure (`cmake -S . -B build -DMIR_ENABLE_STACKTRACE=OFF`) exits 0 with zero CMake errors on `v1.6.2-63-ga328877a`.

To be clear about the limits of that: I did not run a full compile or the test suite, and I had no pre-11.0 CUDA toolkit available to watch the new guard actually fire. Happy to adjust the threshold or move the check if you'd rather it live elsewhere.

Fixes #154