### PR TITLE
cmake: reject a serial HDF5 at configure time

### DIFF
--- a/src/cmake/hdf5.cmake
+++ b/src/cmake/hdf5.cmake
@@ -1,6 +1,18 @@
 set(HDF5_PREFER_PARALLEL ON)
 find_package(HDF5 REQUIRED)
 
+# HDF5_PREFER_PARALLEL is only a preference: when no parallel build is available,
+# find_package() succeeds with a serial HDF5. The XDMF backend then calls MPI-only
+# entry points unconditionally (H5Pset_fapl_mpio, H5Pset_dxpl_mpio in
+# mirheo/core/xdmf/hdf5_helpers.cpp), so the mismatch only surfaces much later as
+# "'H5Pset_dxpl_mpio' was not declared in this scope". Reject it here instead.
+if (NOT HDF5_IS_PARALLEL)
+  message(FATAL_ERROR
+    "Mirheo requires a parallel (MPI-enabled) HDF5 build, but the HDF5 found at "
+    "'${HDF5_INCLUDE_DIRS}' is serial. Install a parallel HDF5 (e.g. libhdf5-openmpi-dev "
+    "or libhdf5-mpich-dev) and, if needed, point HDF5_ROOT at it.")
+endif()
+
 # On CRAY systems things are complicated
 # This workaround should work to supply
 # nvcc with correct hdf paths


### PR DESCRIPTION
HDF5_PREFER_PARALLEL is a preference rather than a requirement, so when no parallel HDF5 is installed find_package(HDF5 REQUIRED) still succeeds with a serial build. The XDMF backend calls MPI-only entry points unconditionally, so the mismatch only appears much later as a compile error in mirheo/core/xdmf/hdf5_helpers.cpp.
### Summary

`src/cmake/hdf5.cmake` sets `HDF5_PREFER_PARALLEL`, which is a preference rather than a requirement: if no parallel HDF5 is installed, `find_package(HDF5 REQUIRED)` still succeeds with a serial build. The XDMF backend then calls MPI-only entry points unconditionally (`H5Pset_fapl_mpio`, `H5Pset_dxpl_mpio` in `mirheo/core/xdmf/hdf5_helpers.cpp`), so the mismatch only surfaces much later as the compile error reported in #155: `error: 'H5Pset_dxpl_mpio' was not declared in this scope`.

`docs/source/user/installation.rst` already lists "HDF5 parallel library" as a requirement — this just makes the build enforce what the docs state.

### Changes

Check `HDF5_IS_PARALLEL` immediately after `find_package(HDF5 REQUIRED)` and abort with a message naming the problem and the likely fix, instead of letting the build fail later inside the XDMF sources.

### Testing

Tested on Google Colab (Tesla T4): CUDA 12.8.93, gcc 11.4.0, CMake 3.31.10, OpenMPI 3.1.

With parallel HDF5 installed via `libhdf5-openmpi-dev`, CMake's `FindHDF5` sets `HDF5_IS_PARALLEL` to `TRUE` (found at `/usr/include/hdf5/openmpi`), the new check does not fire, and a full configure exits 0 with zero CMake errors.

I checked specifically that `HDF5_IS_PARALLEL` is *defined* and not merely truthy, since an undefined variable would make `NOT HDF5_IS_PARALLEL` fire on a parallel install too. On this configuration it is defined. If you know of a platform where your `FindHDF5` leaves it unset, the condition should be tightened to `if (DEFINED HDF5_IS_PARALLEL AND NOT HDF5_IS_PARALLEL)` — happy to make that change if you'd prefer the more conservative form.

I did not have a serial-only HDF5 environment available to watch the new error actually fire.

Fixes #155
Check HDF5_IS_PARALLEL right after find_package and abort with a message that names the problem. The parallel HDF5 requirement is already documented in docs/source/user/installation.rst; this makes the build enforce it.

Refs #155